### PR TITLE
Don't require the DEB maintainer to be specified manually.

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -871,7 +871,7 @@ jobs:
             # 1. Use the same logic as cargo-deb, i.e. take the maintainer from the package.metadata.deb.maintainer
             #    key in Cargo.toml (for the selected variant) if defined, else use the first author instead.
             V=${VARIANT:-null}
-            MAINTAINER=$(cargo read-manifest | jq -r "[.metadata.deb.variants.$V.maintainer, .metadata.deb.maintainer, .authors[0]] | del(..|nulls)[0]")
+            MAINTAINER=$(cargo read-manifest | jq -r '[.metadata.deb.variants."'$V'".maintainer, .metadata.deb.maintainer, .authors[0]] | del(..|nulls)[0]')
 
             # 2. Generate the RFC 5322 format date by hand instead of using date --rfc-email because that option doesn't
             #    exist on Ubuntu 16.04 and Debian 9

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -189,11 +189,6 @@ on:
         required: false
         type: string
         default: ''
-      deb_maintainer:
-        description: "The name and email address of the Debian package maintainers, e.g. `The NLnet Labs RPKI Team <rpki@nlnetlabs.nl>`."
-        required: false
-        type: string
-        default: ''
       deb_apt_key_url:
         description: "When upgrading from a previously published package, this is the URL to the published repository key. Defaults to the NLnet Labs repository key."
         required: false
@@ -435,13 +430,6 @@ jobs:
             fi
           fi
 
-          if [[ '${{ steps.pre_process_rules.outputs.package_build_rules }}' != '{}' ]]; then
-            if [[ '${{ inputs.deb_maintainer }}' == '' ]]; then
-              echo "::error::Workflow input 'deb_maintainer' must be non-empty when 'package_build_rules' are supplied."
-              exit 1
-            fi
-          fi
-          
           if [[ "${{ secrets.DOCKER_HUB_ID }}" != '' || "${{ secrets.DOCKER_HUB_TOKEN }}" != '' ]]; then
             echo "has_docker_secrets=true" >> $GITHUB_OUTPUT
           else
@@ -833,29 +821,6 @@ jobs:
 
         case ${OS_NAME} in
           debian|ubuntu)
-            if [[ '${{ inputs.deb_maintainer }}' == '' ]]; then
-              echo "::error::Workflow input variable 'deb_maintainer' must be non-empty if set."
-              exit 1
-            fi
-
-            MAINTAINER="${{ inputs.deb_maintainer }}"
-
-            # Generate the RFC 5322 format date by hand instead of using date --rfc-email because that option doesn't
-            # exist on Ubuntu 16.04 and Debian 9
-            RFC5322_TS=$(LC_TIME=en_US.UTF-8 date +'%a, %d %b %Y %H:%M:%S %z')
-
-            # Generate the changelog file that Debian packages are required to have.
-            # See: https://www.debian.org/doc/manuals/maint-guide/dreq.en.html#changelog
-            if [ ! -d target/debian ]; then
-              mkdir -p target/debian
-            fi
-            echo "${MATRIX_PKG} (${PKG_APP_VER}) unstable; urgency=medium" >target/debian/changelog
-            echo "  * See: https://github.com/${{ github.repository }}/releases/tag/v${APP_NEW_VER}" >>target/debian/changelog
-            echo " -- maintainer ${MAINTAINER}  ${RFC5322_TS}" >>target/debian/changelog
-
-            echo "Generated changelog:"
-            cat target/debian/changelog
-
             # Ugly hack to use an alternate base Cargo Deb configuration so that the selected variant overrides settings
             # in the specified alternate base settings instead of the usual [package.metadata.deb] base settings.
             if grep -Eq "^\[package\.metadata\.deb_alt_base_${MATRIX_PKG}\]$" Cargo.toml; then
@@ -897,6 +862,36 @@ jobs:
                 echo "::notice file=Cargo.toml::Cargo deb variant '${VARIANT}' not found, using defaults instead."
               fi
             fi
+
+            #
+            # Generate the changelog file that Debian packages are required to have.
+            # See: https://www.debian.org/doc/manuals/maint-guide/dreq.en.html#changelog
+            #
+
+            # 1. Use the same logic as cargo-deb, i.e. take the maintainer from the package.metadata.deb.maintainer
+            #    key in Cargo.toml (for the selected variant) if defined, else use the first author instead.
+            V=${VARIANT:-null}
+            MAINTAINER=$(cargo read-manifest | jq -r "[.metadata.deb.variants.$V.maintainer, .metadata.deb.maintainer, .authors[0]] | del(..|nulls)[0]")
+
+            # 2. Generate the RFC 5322 format date by hand instead of using date --rfc-email because that option doesn't
+            #    exist on Ubuntu 16.04 and Debian 9
+            RFC5322_TS=$(LC_TIME=en_US.UTF-8 date +'%a, %d %b %Y %H:%M:%S %z')
+
+            # 3. Generate the changelog file that Debian packages are required to have.
+            if [ ! -d target/debian ]; then
+              mkdir -p target/debian
+            fi
+            echo "${MATRIX_PKG} (${PKG_APP_VER}) unstable; urgency=medium" >target/debian/changelog
+            echo "  * See: https://github.com/${{ github.repository }}/releases/tag/v${APP_NEW_VER}" >>target/debian/changelog
+            echo " -- maintainer ${MAINTAINER}  ${RFC5322_TS}" >>target/debian/changelog
+
+            # 4. Print the generated changelog for diagnostic purposes
+            echo "Generated changelog:"
+            cat target/debian/changelog
+
+            #
+            # End changelog generation
+            #
 
             DEB_VER="${PKG_APP_VER}-1${OS_REL}"
 

--- a/docs/os_packaging.md
+++ b/docs/os_packaging.md
@@ -78,7 +78,6 @@ jobs:
         pkg: ["mytest"]
         image: ["ubuntu:jammy"]
         target: ["x86_64"]
-      deb_maintainer: 'Build Bot <build.bot@example.com>'
 ```
 
 Assuming that you have just created an empty GitHub repository, let's setup Git to push to it, add & commit the files we have created and push them to GitHub:
@@ -164,7 +163,6 @@ Both `cargo-deb` and `cargo-generate-rpm` have a `variant` feature. Ploutos will
 | `package_test_rules` | [matrix](./key_concepts_and_config.md#matrix-rules) | No | Defines the packages to test and how to test them. See below.  |
 | `package_test_scripts_path` | string | No | The path to find scripts for running tests. Invoked scripts take a single argument: post-install or post-upgrade. |
 | `deb_extra_build_packages` | string | No | A space separated set of additional Debian packages to install in the build host when (not cross) compiling. |
-| `deb_maintainer` | string | No* | The name and email address of the Debian package maintainers, e.g. `The NLnet Labs RPKI Team <rpki@nlnetlabs.nl>`. Required when packaging for a DEB based O/S in order to generate the required [`changelog`](https://www.debian.org/doc/manuals/maint-guide/dreq.en.html#changelog) file. |
 | `deb_apt_key_url` | string | No* | The URL of the public key that can be used to verify a signed package if installing using `deb_apt_source`. Defaults to the NLnet Labs package repository key URL. |
 | `deb_apt_source` | string | No* | A line or lines to write to an APT `/etc/apt/sources.list.d/` file, or the relative path to such a file to install. Used when `mode` of `package_test_rules` is `upgrade-from-published`. Defaults to the NLnet Labs package installation settings. |
 | `rpm_extra_build_packages` | string | No | A space separated set of additional RPM packages to install in the build host when (not cross) compiling. |
@@ -357,7 +355,7 @@ Ploutos is aware of certain cases that must be handled specially, for example:
 
   Where:
   - `${APP_NEW_VER}` is the value of the `version` key in `Cargo.toml`.
-  - `${MAINTAINER}` is the value of the `<deb_maintainer>` workflow input.
+  - `${MAINTAINER}` is the value of the `package.metadata.deb.maintainer` key in `Cargo.toml` (for the selected variant) if set, else the first value set for the `author` key.
   - `${MATRIX_PKG}` is the value of the `<pkg>` matrix key for the current permutation of the package build rules matrix being built.
   - `${PKG_APP_VER}` is the version of the application being built based on `version` in `Cargo.toml` but post-processed to handle things like [pre-releases](#./key_concepts_and_config#application-versions) or [next development versions](#./key_concepts_and_config#next-dev-version).
   - `${RFC5322_TS}` is set to the time now while building.


### PR DESCRIPTION
Instead use the same approach as cargo-deb to determine the package maintainer.

See also the corresponding changes to the tests in https://github.com/NLnetLabs/ploutos-testing/pull/31 and the associated successful test run here: https://github.com/NLnetLabs/ploutos-testing/actions/runs/3514130971