### PR TITLE
Default pkg test rules to pkg build rules

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -150,10 +150,10 @@ on:
         type: string
         default: '{}'
       package_test_rules:
-        description: "A relative path to a YAML file, or a YAML string, containing a GitHub Actions matrix with 'pkg' (from package_build_rules), LXC 'image' (<dist>:<rel>), 'target' (from package_build_rules) and 'mode' (fresh-install or upgrade-from-published). See also: https://uk.lxd.images.canonical.com/"
-        required: false
-        type: string
-        default: '{}'
+          description: "'use_package_build_rules' (default), 'none', or a relative path to a YAML file, or a YAML string, containing a GitHub Actions matrix with 'pkg' (from package_build_rules), LXC 'image' (<dist>:<rel>), 'target' (from package_build_rules) and 'mode' (fresh-install or upgrade-from-published). See also: https://uk.lxd.images.canonical.com/"
+          required: false
+          type: string
+          default: 'use_package_build_rules'
 
       # Using Docker Hub terminology, for a Docker image named nlnetlabs/krill:v0.1.2-arm64:
       #   - The Organization would be 'nlnetlabs'.
@@ -318,7 +318,11 @@ jobs:
           echo 'END_OF_PACKAGE_BUILD_RULES' >> $GITHUB_OUTPUT
 
           echo "package_test_rules<<END_OF_PACKAGE_TEST_RULES" >> $GITHUB_OUTPUT
-          if [[ -f '${{ inputs.package_test_rules }}' ]]; then
+          if [[ '${{ inputs.package_test_rules }}' == 'none' ]]; then
+            JSON='{}'
+          elif [[ '${{ inputs.package_test_rules }}' == 'use_package_build_rules' ]]; then
+            JSON=$(yq '${{ inputs.package_build_rules }}' -I=0 -p=yaml -o=json)
+          elif [[ -f '${{ inputs.package_test_rules }}' ]]; then
             JSON=$(yq '${{ inputs.package_test_rules }}' -I=0 -p=yaml -o=json)
           else
             JSON=$(echo '${{ inputs.package_test_rules }}' | yq -I=0 -p=yaml -o=json)

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1136,6 +1136,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Verify inputs
+      id: verify
       run: |
         if [[ '${{ matrix.image }}' == '' ]]; then
           echo "::error::Required matrix variable 'image' is not defined in package_test_rules."
@@ -1150,6 +1151,12 @@ jobs:
         if [[ '${{ matrix.pkg }}' == '' ]]; then
           echo "::error::Required matrix variable 'pkg' is not defined in package_test_rules."
           exit 1
+        fi
+
+        if [[ '${{ matrix.mode }}' == '' ]]; then
+          echo "mode=fresh-install" >> $GITHUB_OUTPUT
+        else
+          echo "mode=${{ matrix.mode }}" >> $GITHUB_OUTPUT
         fi
 
     # Set some environment variables that will be available to "run" steps below in this job, and some output variables
@@ -1256,7 +1263,7 @@ jobs:
 
     - name: Install previously published ${{ matrix.pkg }} package
       id: instprev
-      if: ${{ matrix.mode == 'upgrade-from-published' }}
+      if: ${{ steps.verify.outputs.mode == 'upgrade-from-published' }}
       run: |
         case ${OS_NAME} in
           debian|ubuntu)
@@ -1304,7 +1311,7 @@ jobs:
         esac
 
     - name: Install the newly built ${{ matrix.pkg }} package
-      if: ${{ matrix.mode == 'fresh-install' }}
+      if: ${{ steps.verify.outputs.mode == 'fresh-install' }}
       run: |
         case ${OS_NAME} in
           debian|ubuntu)
@@ -1318,7 +1325,7 @@ jobs:
         esac
 
     - name: Test the installed ${{ matrix.pkg }} package
-      if: ${{ inputs.package_test_scripts_path != '' && matrix.mode == 'fresh-install' }}
+      if: ${{ inputs.package_test_scripts_path != '' && steps.verify.outputs.mode == 'fresh-install' }}
       run: |
         TEST_SCRIPT="$(echo '${{ inputs.package_test_scripts_path }}' | sed -e 's/<package>/${{ matrix.pkg }}/g')"
         sg lxd -c "lxc file push ${TEST_SCRIPT} testcon/tmp/test.sh"
@@ -1328,7 +1335,7 @@ jobs:
     - name: Upgrade from the published ${{ matrix.pkg }} package to the newly built package
       id: upgrade_package
       continue-on-error: true
-      if: ${{ matrix.mode == 'upgrade-from-published' }}
+      if: ${{ steps.verify.outputs.mode == 'upgrade-from-published' }}
       run: |
         case ${OS_NAME} in
           debian|ubuntu)
@@ -1350,7 +1357,7 @@ jobs:
           core.setFailed("Package upgrade failed unexpectedly")
 
     - name: Verify that conffiles have not been altered by the upgrade
-      if: ${{ matrix.mode == 'upgrade-from-published' }}
+      if: ${{ steps.verify.outputs.mode == 'upgrade-from-published' }}
       run: |
         case ${OS_NAME} in
           debian|ubuntu)
@@ -1362,7 +1369,7 @@ jobs:
         esac
 
     - name: Test the upgraded ${{ matrix.pkg }} package
-      if: ${{ inputs.package_test_scripts_path != '' && matrix.mode == 'upgrade-from-published' }}
+      if: ${{ inputs.package_test_scripts_path != '' && steps.verify.outputs.mode == 'upgrade-from-published' }}
       run: |
         TEST_SCRIPT="$(echo '${{ inputs.package_test_scripts_path }}' | sed -e 's/<package>/${{ matrix.pkg }}/g')"
         sg lxd -c "lxc file push ${TEST_SCRIPT} testcon/tmp/test2.sh"

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -332,7 +332,7 @@ jobs:
           if [[ "${JSON}" != "{}" ]]; then
             CONTROL_JSON=$(echo ${JSON} | jq -c)
             MODIFIED_JSON=$(echo ${JSON} | jq -c 'del(.image[] | select(. == "debian:stretch")) | del(.include[] | select(.image == "debian:stretch"))')
-            MODIFIED_JSON=$(echo ${MODIFIED_JSON} | jq -c 'del(.os[] | select(. == "debian:stretch")) | del(.include[] | select(.os == "debian:stretch"))')
+            MODIFIED_JSON=$(echo ${MODIFIED_JSON} | jq -c 'del(.include[] | select(.os == "debian:stretch"))')
             if [[ "${CONTROL_JSON}" != "${MODIFIED_JSON}" ]]; then
               echo "::warning::Removed debian:stretch image from package_test_rules because the LXC image no longer exists"
               JSON="${MODIFIED_JSON}"

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1159,13 +1159,19 @@ jobs:
           echo "mode=${{ matrix.mode }}" >> $GITHUB_OUTPUT
         fi
 
+        if [[ '${{ matrix.os }}' == '' ]]; then
+          echo "image=${{ matrix.image }}" >> $GITHUB_OUTPUT
+        else
+          echo "image=${{ matrix.os }}" >> $GITHUB_OUTPUT
+        fi
+
     # Set some environment variables that will be available to "run" steps below in this job, and some output variables
     # that will be available in GH Action step definitions below.
     - name: Set vars
       id: setvars
       shell: bash
       env:
-        MATRIX_IMAGE: ${{ matrix.image }}
+        MATRIX_IMAGE: ${{ steps.verify.outputs.image }}
       run: |
         # Get the operating system and release name (e.g. ubuntu and xenial) from the image name (e.g. ubuntu:xenial) by
         # extracting only the parts before and after but not including the colon:

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -333,10 +333,21 @@ jobs:
             CONTROL_JSON=$(echo ${JSON} | jq 'del(.image[] | select(. == "i-dont-exist"))' | jq -c)
             MODIFIED_JSON=$(echo ${JSON} | jq 'del(.image[] | select(. == "debian:stretch"))' | jq -c)
             if [[ "${CONTROL_JSON}" != "${MODIFIED_JSON}" ]]; then
-              echo "::warning::Removed debian:stretch from package_test_rules because the LXC image no longer exists"
+              echo "::warning::Removed debian:stretch image from package_test_rules because the LXC image no longer exists"
               JSON="${MODIFIED_JSON}"
             fi
           fi
+
+          # Exclude non-x86_64 targets as we only run the tests on x86-64 GitHub runners
+          if [[ "${JSON}" != "{}" ]]; then
+            CONTROL_JSON=$(echo ${JSON} | jq 'del(.target[] | select(. == "i-dont-exist"))' | jq -c)
+            MODIFIED_JSON=$(echo ${JSON} | jq 'del(.target[] | select(. != "x86_64"))' | jq -c)
+            if [[ "${CONTROL_JSON}" != "${MODIFIED_JSON}" ]]; then
+              echo "::warning::Removed non-x86_64 target from package_test_rules because testing is only supported for x86_64 targets"
+              JSON="${MODIFIED_JSON}"
+            fi
+          fi
+
           echo ${JSON} | jq >> $GITHUB_OUTPUT
           echo 'END_OF_PACKAGE_TEST_RULES' >> $GITHUB_OUTPUT
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -330,8 +330,9 @@ jobs:
 
           # Exclude debian:stretch because the LXC image is no longer available
           if [[ "${JSON}" != "{}" ]]; then
-            CONTROL_JSON=$(echo ${JSON} | jq 'del(.image[] | select(. == "i-dont-exist"))' | jq -c)
-            MODIFIED_JSON=$(echo ${JSON} | jq 'del(.image[] | select(. == "debian:stretch"))' | jq -c)
+            CONTROL_JSON=$(echo ${JSON} | jq -c)
+            MODIFIED_JSON=$(echo ${JSON} | jq -c 'del(.image[] | select(. == "debian:stretch")) | del(.include[] | select(.image == "debian:stretch"))')
+            MODIFIED_JSON=$(echo ${MODIFIED_JSON} | jq -c 'del(.os[] | select(. == "debian:stretch")) | del(.include[] | select(.os == "debian:stretch"))')
             if [[ "${CONTROL_JSON}" != "${MODIFIED_JSON}" ]]; then
               echo "::warning::Removed debian:stretch image from package_test_rules because the LXC image no longer exists"
               JSON="${MODIFIED_JSON}"
@@ -340,8 +341,8 @@ jobs:
 
           # Exclude non-x86_64 targets as we only run the tests on x86-64 GitHub runners
           if [[ "${JSON}" != "{}" ]]; then
-            CONTROL_JSON=$(echo ${JSON} | jq 'del(.target[] | select(. == "i-dont-exist"))' | jq -c)
-            MODIFIED_JSON=$(echo ${JSON} | jq 'del(.target[] | select(. != "x86_64"))' | jq -c)
+            CONTROL_JSON=$(echo ${JSON} | jq -c)
+            MODIFIED_JSON=$(echo ${JSON} | jq -c 'del(.target[] | select(. != "x86_64")) | del(.include[] | select(.target != "x86_64"))')
             if [[ "${CONTROL_JSON}" != "${MODIFIED_JSON}" ]]; then
               echo "::warning::Removed non-x86_64 target from package_test_rules because testing is only supported for x86_64 targets"
               JSON="${MODIFIED_JSON}"

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -344,7 +344,7 @@ jobs:
             CONTROL_JSON=$(echo ${JSON} | jq -c)
             MODIFIED_JSON=$(echo ${JSON} | jq -c 'del(.target[] | select(. != "x86_64")) | del(.include[] | select(.target != "x86_64"))')
             if [[ "${CONTROL_JSON}" != "${MODIFIED_JSON}" ]]; then
-              echo "::warning::Removed non-x86_64 target from package_test_rules because testing is only supported for x86_64 targets"
+              echo "::warning::Removed non-x86_64 targets from package_test_rules because testing is only supported for x86_64 targets"
               JSON="${MODIFIED_JSON}"
             fi
           fi

--- a/docs/os_packaging.md
+++ b/docs/os_packaging.md
@@ -208,9 +208,15 @@ It may not matter which O/S release the RPM or DEB package is built inside, exce
 
 ### Package test rules
 
-By supplying `package_test_rules` you instruct Ploutos to test your packages (beyond the basic verification done post-build).
+`package_test_rules` instructs Ploutos to test your packages (beyond the basic verification done post-build).
 
-Testing packages is optional. Only packages that were built using `package_build_rules` can be tested.
+Only packages that were built using `package_build_rules` can be tested. By default the packages built according to  `package_build_rules` will be tested, minus any packages for which testing is not supported (e.g. missing LXC image or unsupported architecture). 
+
+Testing packages is optional. To disable testing of packages completely set `package_test_rules` to `none`.
+
+To test package upgrade you must also supply the `deb_apt_xxx` and/or `rpm_yum_xxx` workflow inputs as needed by your packages. To test upgrade of all built packages without supplying `package_test_rules`, add a `mode` key to the `package_build_rules` matrix with value `upgrade-from-published`.
+
+If you wish to test only a subset of the built packages and/or wish to test package upgrade with only a subset of the packages, then you will need to fully specify the `package_test_rules` input matrix.
 
 The testing process looks like this:
 


### PR DESCRIPTION
This PR implements support for #2.

See test run https://github.com/NLnetLabs/ploutos-testing/actions/runs/3516018256 which adds jobs `default_tests` and modifies the definition of the existing `no_tests` job.

The added job does not specify any tests and so uses the new default behaviour in this PR of testing the same packages that were built, minus any for which testing is not supported.

The modified job disables testing explicitly using the new special value `none` for the `package_test_rules` input, overriding the new default behaviour.

This PR also fixes the existing behaviour of excluding testing for the `debian:stretch` image by also matching it when mentioned in the `include` array or when aliased via the `os` key (since we now take our input from `package_build_rules` by default which supports the `os `key).

This PR also defaults the `mode` matrix field to `fresh-install` because we don't want users to have to specify this obvious default, especially when removing the need to specify `package_test_rules` at all for the common case.

And finally this PR somewhat implicitly adds in support for specifying `mode` in `package_build_rules` given that `package_build_rules` will may be used by default now but did not support this additional key that the `package_test_rules` matrix supports.