### PR TITLE
v5 release prep

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -984,7 +984,7 @@ jobs:
             # command line argument.
             if [[ "${{ inputs.rpm_scriptlets_path }}" != "" ]]; then
               # Download the RPM systemd macros shell functions file fragment
-              SYSTEMD_RPM_MACROS_URL="https://raw.githubusercontent.com/NLnetLabs/ploutos/v4.0.0/fragments/macros.systemd.sh"
+              SYSTEMD_RPM_MACROS_URL="https://raw.githubusercontent.com/NLnetLabs/ploutos/v5.0.0/fragments/macros.systemd.sh"
               SYSTEMD_RPM_MACROS_FILE="/tmp/systemd_rpm_macros"
               curl --proto '=https' --tlsv1.2 --fail --output ${SYSTEMD_RPM_MACROS_FILE} ${SYSTEMD_RPM_MACROS_URL}
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -342,7 +342,7 @@ jobs:
           # Exclude non-x86_64 targets as we only run the tests on x86-64 GitHub runners
           if [[ "${JSON}" != "{}" ]]; then
             CONTROL_JSON=$(echo ${JSON} | jq -c)
-            MODIFIED_JSON=$(echo ${JSON} | jq -c 'del(.target[] | select(. != "x86_64")) | del(.include[] | select(.target != "x86_64"))')
+            MODIFIED_JSON=$(echo ${JSON} | jq -c 'del(.target[] | select(. != "x86_64")) | del(.include[] | select(.target != "x86_64" and .target != null))')
             if [[ "${CONTROL_JSON}" != "${MODIFIED_JSON}" ]]; then
               echo "::warning::Removed non-x86_64 targets from package_test_rules because testing is only supported for x86_64 targets"
               JSON="${MODIFIED_JSON}"

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -984,7 +984,7 @@ jobs:
             # command line argument.
             if [[ "${{ inputs.rpm_scriptlets_path }}" != "" ]]; then
               # Download the RPM systemd macros shell functions file fragment
-              SYSTEMD_RPM_MACROS_URL="https://raw.githubusercontent.com/NLnetLabs/ploutos/v5.0.0/fragments/macros.systemd.sh"
+              SYSTEMD_RPM_MACROS_URL="https://raw.githubusercontent.com/NLnetLabs/ploutos/v5/fragments/macros.systemd.sh"
               SYSTEMD_RPM_MACROS_FILE="/tmp/systemd_rpm_macros"
               curl --proto '=https' --tlsv1.2 --fail --output ${SYSTEMD_RPM_MACROS_FILE} ${SYSTEMD_RPM_MACROS_URL}
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -311,10 +311,19 @@ jobs:
 
           echo "package_build_rules<<END_OF_PACKAGE_BUILD_RULES" >> $GITHUB_OUTPUT
           if [[ -f '${{ inputs.package_build_rules }}' ]]; then
-            yq '${{ inputs.package_build_rules }}' -p=yaml -o=json >> $GITHUB_OUTPUT
+            JSON=$(yq '${{ inputs.package_build_rules }}' -I=0 -p=yaml -o=json)
           else
-            echo '${{ inputs.package_build_rules }}' | yq -p=yaml -o=json >> $GITHUB_OUTPUT
+            JSON=$(echo '${{ inputs.package_build_rules }}' | yq -I=0 -p=yaml -o=json)
           fi
+
+          # Don't permute the build job over variables intended only for use by the pkg-test job but which were supplied
+          # via package_build_rules as a convenience for the user to avoid having to supply package_test_rules which
+          # would be mostly identical to package_build_rules. If we don't remove this we end up causing duplicate Build
+          # jobs to be spawned for each different test mode (fresh-install vs upgrade-from-published) which for the
+          # pkb job are identical and thus pointless waste and just plain confusing.
+          MODIFIED_JSON=$(echo ${JSON} | jq -c 'del(.mode)')
+
+          echo ${MODIFIED_JSON} | jq >> $GITHUB_OUTPUT
           echo 'END_OF_PACKAGE_BUILD_RULES' >> $GITHUB_OUTPUT
 
           echo "package_test_rules<<END_OF_PACKAGE_TEST_RULES" >> $GITHUB_OUTPUT

--- a/docs/README.md
+++ b/docs/README.md
@@ -115,7 +115,7 @@ on:
 
 jobs:
   my_pkg_job:
-    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v4
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v5
 ```
 
 _**Note:** this will **NOT** actually build any packages as it doesn't indicate which types of package to build or provide the necessary supporting information!_

--- a/docs/docker_packaging.md
+++ b/docs/docker_packaging.md
@@ -71,7 +71,7 @@ Example using an inline YAML string matrix definition:
 ```yaml
 jobs:
   my_pkg_job:
-    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v4
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v5
     with:
       docker_build_rules: |
         include:
@@ -106,7 +106,7 @@ The Ploutos workflow supports two Docker specific secrets which can be passed to
 ```yaml
 jobs:
   full:
-    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v4
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v5
     secrets:
       DOCKER_HUB_ID: ${{ secrets.YOUR_DOCKER_HUB_ID }}
       DOCKER_HUB_TOKEN: ${{ secrets.YOUR_DOCKER_HUB_TOKEN }}
@@ -117,7 +117,7 @@ Or, if you are willing to trust the packaging workflow with all of your secrets!
 ```yaml
 jobs:
   full:
-    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v4
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v5
     secrets: inherit
 ```
 

--- a/docs/key_concepts_and_config.md
+++ b/docs/key_concepts_and_config.md
@@ -15,7 +15,7 @@ When you refer to the Ploutos workflow you are also indicating which version of 
 ```yaml
 jobs:
   my_pkg_job:
-    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v4
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v5
 ```
 
 Here we see that the v3 version of the workflow will be used.
@@ -24,7 +24,7 @@ What may not be obvious is that this will work for v3.0.0, v3.0.1, v3.3.4 and so
 
 The version number consists of MAJOR.MINOR.PATCH components. Any change in minor and patch versions should be backward compatible and thus safe to use automatically.
 
-If a backward incompatible change is made however then the the major version number will be increased, e.g. from `v3` to `v4`. In that case you will not get the new version with the breaking changes unless you manually update the `uses` line in your workfow to refer to the new major version.
+If a backward incompatible change is made however then the the major version number will be increased, e.g. from `v5` to `v6`. In that case you will not get the new version with the breaking changes unless you manually update the `uses` line in your workfow to refer to the new major version.
 
 ## Application versions
 
@@ -77,7 +77,7 @@ An input of "matrix" type can be specified in one of two ways:
   ```yaml
   jobs:
     my_pkg_job:
-      uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v4
+      uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v5
       with:
         cross_build_rules: |
           target:
@@ -90,7 +90,7 @@ An input of "matrix" type can be specified in one of two ways:
   ```yaml
   jobs:
     my_pkg_job:
-      uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v4
+      uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v5
       with:
         cross_build_rules: pkg/rules/cross_build_rules.yml
   ```

--- a/docs/minimal_useful_example.md
+++ b/docs/minimal_useful_example.md
@@ -49,7 +49,7 @@ on:
 
 jobs:
   my_pkg_job:
-    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v4
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v5
     with:
       docker_org: my_org
       docker_repo: my_image_name

--- a/docs/os_packaging.md
+++ b/docs/os_packaging.md
@@ -160,7 +160,7 @@ Both `cargo-deb` and `cargo-generate-rpm` have a `variant` feature. Ploutos will
 | Input | Type | Required | Description |
 |---|---|---|---|
 | `package_build_rules` | [matrix](./key_concepts_and_config.md#matrix-rules) | Yes | Defines packages to build and how to build them. See below. |
-| `package_test_rules` | [matrix](./key_concepts_and_config.md#matrix-rules) | No | Defines the packages to test and how to test them. See below.  |
+| `package_test_rules` | [matrix](./key_concepts_and_config.md#matrix-rules) | No | Defines the packages to test and how to test them. Defaults to `package_build_rules`. See below.  |
 | `package_test_scripts_path` | string | No | The path to find scripts for running tests. Invoked scripts take a single argument: post-install or post-upgrade. |
 | `deb_extra_build_packages` | string | No | A space separated set of additional Debian packages to install in the build host when (not cross) compiling. |
 | `deb_apt_key_url` | string | No* | The URL of the public key that can be used to verify a signed package if installing using `deb_apt_source`. Defaults to the NLnet Labs package repository key URL. |
@@ -192,6 +192,8 @@ A rules [matrix](./key_concepts_and_config.md#matrix-rules) with the following k
 | `extra_build_args` | No | A space separated set of additional command line arguments to pass to `cargo-deb`/`cargo build`. |
 | `rpm_systemd_service_unit_file` | No | Relative path to the systemd file, or files (if it ends with `*`) to inclde in an RPM package. See below for more info. |
 
+**Note:** When `package_test_rules` is not supplied the `package_build_rules` matrix is also used as the `package_test_rules` matrix, since normally you want to test every package that you build. When using `package_build_rules` this way you can also supply `package_test_rules` matrix keys in the `package_build_rules` input. These will be ignored by the package building workflow job.
+
 #### Permitted `<image>` values
 
 The `<image>` **MUST** be one of the following:
@@ -210,7 +212,7 @@ It may not matter which O/S release the RPM or DEB package is built inside, exce
 
 `package_test_rules` instructs Ploutos to test your packages (beyond the basic verification done post-build).
 
-Only packages that were built using `package_build_rules` can be tested. By default the packages built according to  `package_build_rules` will be tested, minus any packages for which testing is not supported (e.g. missing LXC image or unsupported architecture). 
+Only packages that were built using `package_build_rules` can be tested. By default the packages built according to  `package_build_rules` will be tested, minus any packages for which testing is not supported (e.g. missing LXC image or unsupported architecture).
 
 Testing packages is optional. To disable testing of packages completely set `package_test_rules` to `none`.
 

--- a/docs/os_packaging.md
+++ b/docs/os_packaging.md
@@ -72,7 +72,7 @@ on:
   
 jobs:
   package:
-    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v4
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v5
     with:
       package_build_rules: |
         pkg: ["mytest"]


### PR DESCRIPTION
- [x] 1. Create a branch in the RELEASE repo, let's call this the RELEASE branch.
- [x] 2. Change RPM_MACROS_URL in the workflow to point to the new RELEASE branch.
- [x] 3. Create a PR in the RELEASE repo for the RELEASE branch.
- [x] 4. Create a matching branch in the TEST repo, let's call this the TEST branch.
- [x] 5. Make the desired changes to the RELEASE branch.
- [x] 6. In the TEST branch modify `.github/workflows/pkg.yml` so that instead of referring to `pkg-rust.yml@vX` it refers to `pkg-rust.yml@<Git ref of HEAD commit on the TEST branch>` or `pkg-rust.yml@<test branch name>`.
- [x] 7. Create a PR in the `.gihub-testing` repository from the TEST branch to `main`, let's call this the TEST PR.
- [x] 8. Repeat steps 4 and 5 until the the `Packaging` workflow run in the TEST PR passes and behaves as desired.
- [x] 9. Merge the TEST PR to the `main` branch.
- [x] 10. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo against the `main` branch passes and behaves as desired. If not, repeat steps 4-9 until the new TEST PR passes and behaves as desired.
- [x] 11. Create a release tag in the TEST repo with the same release tag as will be used in the RELEASE repo, e.g. v1.2.3. _**Note:** Remember to respect semantic versioning, i.e. if the changes being made are not backward compatible you will need to bump the MAJOR version (in MAJOR.MINOR.PATCH) **and** any workflows that invoke the reusable workflow will need to be **manually edited** to refer to the new MAJOR version._
- [x] 12. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo passes against the newly created release tag passes and behaves as desired. If not, delete the release tag **in the TEST repo** and repeat steps 4-11 until the new TEST PR passes and behaves as desired.
- [ ] 13. Merge the RELEASE PR to the `main` branch.
- [ ] 14. Change RPM_MACROS_URL in the workflow to point to vX.Y.Z tag (that you are about to create).
- [ ] 15. Create the new release vX.Y.Z tag in the RELEASE repo.
- [ ] 16. Update the vX tag in the RELEASE repo to point to the new vX.Y.Z tag.
- [ ] 17. Edit `.github/workflows/pkg.yml` in the `main` branch of the TEST repo to refer again to `@vX`.
- [ ] 18. Verify that the `Packaging` action in the TEST repo against the `main` branch passes and works as desired.
- [ ] 19. (optional) If the MAJOR version was changed, update affected repositories that use the reusable workflow to use the new MAJOR version, including adjusting to any breaking changes introduced by the MAJOR version change.