### PR TITLE
v5.0.1

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -144,6 +144,12 @@ on:
         required: false
         type: string
         default: '10'
+      strict_mode:
+        description: "if true, certain types of potential spurious warning or error that are usually ignored will instead be considered fatal. Defaults to false."
+        required: false
+        type: boolean
+        default: false
+
       package_build_rules:
         description: "A relative path to a YAML file, or a YAML string, containing a GitHub Actions matrix with 'pkg' (your app name), Docker 'image' (image <os>:<rel>), 'target' (x86_64, or a Rust target triple), 'extra_build_args' (optional), 'os' (optional) fields. See also: https://doc.rust-lang.org/nightly/rustc/platform-support.html"
         required: false
@@ -1114,6 +1120,11 @@ jobs:
             else
               EXTRA_LINTIAN_ARGS="--suppress-tags unstripped-binary-or-object,statically-linked-binary"
             fi
+
+            if [[ "${{ inputs.strict_mode }}" == "true" ]]; then
+              EXTRA_LINTIAN_ARGS="${EXTRA_LINTIAN_ARGS} --fail-on-warnings"
+            fi
+
             lintian --version
             lintian -v ${EXTRA_LINTIAN_ARGS} target/debian/*.deb
             ;;

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -638,6 +638,8 @@ jobs:
 
     - name: Verify inputs
       run: |
+        echo ${{ matrix }}
+
         if [[ ! -f Cargo.toml ]]; then
           echo "::error::File 'Cargo.toml' is missing. This workflow is only intended for use with Rust Cargo projects."
           exit 1
@@ -1187,6 +1189,8 @@ jobs:
     - name: Verify inputs
       id: verify
       run: |
+        echo ${{ matrix }}
+
         if [[ '${{ matrix.image }}' == '' ]]; then
           echo "::error::Required matrix variable 'image' is not defined in package_test_rules."
           exit 1
@@ -1484,6 +1488,8 @@ jobs:
       - name: Verify inputs
         id: verify
         run: |
+          echo ${{ matrix }}
+
           MODE="${{ matrix.mode }}"
 
           case ${MODE} in

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -638,7 +638,7 @@ jobs:
 
     - name: Verify inputs
       run: |
-        echo ${{ toJSON(matrix) }}
+        echo '${{ toJSON(matrix) }}'
 
         if [[ ! -f Cargo.toml ]]; then
           echo "::error::File 'Cargo.toml' is missing. This workflow is only intended for use with Rust Cargo projects."
@@ -1189,7 +1189,7 @@ jobs:
     - name: Verify inputs
       id: verify
       run: |
-        echo ${{ toJSON(matrix) }}
+        echo '${{ toJSON(matrix) }}'
 
         if [[ '${{ matrix.image }}' == '' ]]; then
           echo "::error::Required matrix variable 'image' is not defined in package_test_rules."
@@ -1488,7 +1488,7 @@ jobs:
       - name: Verify inputs
         id: verify
         run: |
-          echo ${{ toJSON(matrix) }}
+          echo '${{ toJSON(matrix) }}'
 
           MODE="${{ matrix.mode }}"
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1122,11 +1122,11 @@ jobs:
             fi
 
             if [[ "${{ inputs.strict_mode }}" == "true" ]]; then
-              EXTRA_LINTIAN_ARGS="${EXTRA_LINTIAN_ARGS} --fail-on-warnings"
+              EXTRA_LINTIAN_ARGS="${EXTRA_LINTIAN_ARGS} --fail-on error,warning"
             fi
 
             lintian --version
-            lintian -v ${EXTRA_LINTIAN_ARGS} target/debian/*.deb
+            lintian --allow-root -v ${EXTRA_LINTIAN_ARGS} target/debian/*.deb
             ;;
           centos)
             # cargo generate-rpm creates RPMs that rpmlint considers to have errors so don't use the rpmlint exit code

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -906,8 +906,13 @@ jobs:
 
             # 1. Use the same logic as cargo-deb, i.e. take the maintainer from the package.metadata.deb.maintainer
             #    key in Cargo.toml (for the selected variant) if defined, else use the first author instead.
+            #
+            # Note:
+            #    With jq 1.6: del(..|nulls)
+            #    With jq 1.5: del(recurse(.[]?;true)|select(. == null))
+            #    Older systems only have jq 1.5 so we have to use the more verbose construct.
             V=${VARIANT:-null}
-            MAINTAINER=$(cargo read-manifest | jq -r '[.metadata.deb.variants."'$V'".maintainer, .metadata.deb.maintainer, .authors[0]] | del(..|nulls)[0]')
+            MAINTAINER=$(cargo read-manifest | jq -r '[.metadata.deb.variants."'$V'".maintainer, .metadata.deb.maintainer, .authors[0]] | del(recurse(.[]?;true)|select(. == null))[0]')
 
             # 2. Generate the RFC 5322 format date by hand instead of using date --rfc-email because that option doesn't
             #    exist on Ubuntu 16.04 and Debian 9

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1133,6 +1133,7 @@ jobs:
                 *)
                   EXTRA_LINTIAN_ARGS="${EXTRA_LINTIAN_ARGS} --fail-on error,warning"
                   ;;
+              esac
             fi
 
             lintian --version

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -210,6 +210,11 @@ on:
         required: false
         type: string
         default: 'deb [arch=amd64] https://packages.nlnetlabs.nl/linux/${OS_NAME}/ ${OS_REL} main'
+      deb_extra_lintian_args:
+        description: "Extra arguments to pass to Lintian, the DEB package verification tool."
+        required: false
+        type: string
+        default: 
 
       cross_build_args:
         description: "Extra arguments to cargo build when cross-compiling, e.g. `--features static-openssl`."
@@ -1115,10 +1120,11 @@ jobs:
         case ${OS_NAME} in
           debian|ubuntu)
             dpkg --info target/debian/*.deb
-            if [[ "${CROSS_TARGET}" == "x86_64" ]]; then
-              EXTRA_LINTIAN_ARGS=
-            else
-              EXTRA_LINTIAN_ARGS="--suppress-tags unstripped-binary-or-object,statically-linked-binary"
+
+            EXTRA_LINTIAN_ARGS="${{ inputs.deb_extra_lintian_args }}"
+
+            if [[ "${CROSS_TARGET}" != "x86_64" ]]; then
+              EXTRA_LINTIAN_ARGS="${EXTRA_LINTIAN_ARGS} --suppress-tags unstripped-binary-or-object,statically-linked-binary"
             fi
 
             if [[ "${{ inputs.strict_mode }}" == "true" ]]; then

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -210,11 +210,6 @@ on:
         required: false
         type: string
         default: 'deb [arch=amd64] https://packages.nlnetlabs.nl/linux/${OS_NAME}/ ${OS_REL} main'
-      deb_extra_lintian_args:
-        description: "Extra arguments to pass to Lintian, the DEB package verification tool."
-        required: false
-        type: string
-        default: 
 
       cross_build_args:
         description: "Extra arguments to cargo build when cross-compiling, e.g. `--features static-openssl`."
@@ -1121,7 +1116,7 @@ jobs:
           debian|ubuntu)
             dpkg --info target/debian/*.deb
 
-            EXTRA_LINTIAN_ARGS="${{ inputs.deb_extra_lintian_args }}"
+            EXTRA_LINTIAN_ARGS="${{ matrix.deb_extra_lintian_args }}"
 
             if [[ "${CROSS_TARGET}" != "x86_64" ]]; then
               EXTRA_LINTIAN_ARGS="${EXTRA_LINTIAN_ARGS} --suppress-tags unstripped-binary-or-object,statically-linked-binary"

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1128,6 +1128,7 @@ jobs:
 
                 bionic|stretch|buster)
                   EXTRA_LINTIAN_ARGS="${EXTRA_LINTIAN_ARGS} --fail-on-warnings"
+                  ;;
 
                 *)
                   EXTRA_LINTIAN_ARGS="${EXTRA_LINTIAN_ARGS} --fail-on error,warning"

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -638,7 +638,7 @@ jobs:
 
     - name: Verify inputs
       run: |
-        echo ${{ matrix }}
+        echo ${{ toJSON(matrix) }}
 
         if [[ ! -f Cargo.toml ]]; then
           echo "::error::File 'Cargo.toml' is missing. This workflow is only intended for use with Rust Cargo projects."
@@ -1189,7 +1189,7 @@ jobs:
     - name: Verify inputs
       id: verify
       run: |
-        echo ${{ matrix }}
+        echo ${{ toJSON(matrix) }}
 
         if [[ '${{ matrix.image }}' == '' ]]; then
           echo "::error::Required matrix variable 'image' is not defined in package_test_rules."
@@ -1488,7 +1488,7 @@ jobs:
       - name: Verify inputs
         id: verify
         run: |
-          echo ${{ matrix }}
+          echo ${{ toJSON(matrix) }}
 
           MODE="${{ matrix.mode }}"
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1122,7 +1122,16 @@ jobs:
             fi
 
             if [[ "${{ inputs.strict_mode }}" == "true" ]]; then
-              EXTRA_LINTIAN_ARGS="${EXTRA_LINTIAN_ARGS} --fail-on error,warning"
+              case ${OS_REL} in
+                focal)
+                  ;;
+
+                bionic|stretch|buster)
+                  EXTRA_LINTIAN_ARGS="${EXTRA_LINTIAN_ARGS} --fail-on-warnings"
+
+                *)
+                  EXTRA_LINTIAN_ARGS="${EXTRA_LINTIAN_ARGS} --fail-on error,warning"
+                  ;;
             fi
 
             lintian --version

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1010,7 +1010,7 @@ jobs:
             # command line argument.
             if [[ "${{ inputs.rpm_scriptlets_path }}" != "" ]]; then
               # Download the RPM systemd macros shell functions file fragment
-              SYSTEMD_RPM_MACROS_URL="https://raw.githubusercontent.com/NLnetLabs/ploutos/v5/fragments/macros.systemd.sh"
+              SYSTEMD_RPM_MACROS_URL="https://raw.githubusercontent.com/NLnetLabs/ploutos/v5.0.1/fragments/macros.systemd.sh"
               SYSTEMD_RPM_MACROS_FILE="/tmp/systemd_rpm_macros"
               curl --proto '=https' --tlsv1.2 --fail --output ${SYSTEMD_RPM_MACROS_FILE} ${SYSTEMD_RPM_MACROS_URL}
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -636,10 +636,14 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
-    - name: Verify inputs
+    - name: Print matrix
+      # Disable default use of bash -x for easier to read output in the log
+      shell: bash
       run: |
         echo '${{ toJSON(matrix) }}'
 
+    - name: Verify inputs
+      run: |
         if [[ ! -f Cargo.toml ]]; then
           echo "::error::File 'Cargo.toml' is missing. This workflow is only intended for use with Rust Cargo projects."
           exit 1
@@ -1186,11 +1190,15 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
-    - name: Verify inputs
-      id: verify
+    - name: Print matrix
+      # Disable default use of bash -x for easier to read output in the log
+      shell: bash
       run: |
         echo '${{ toJSON(matrix) }}'
 
+    - name: Verify inputs
+      id: verify
+      run: |
         if [[ '${{ matrix.image }}' == '' ]]; then
           echo "::error::Required matrix variable 'image' is not defined in package_test_rules."
           exit 1
@@ -1485,11 +1493,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Verify inputs
-        id: verify
+      - name: Print matrix
+        # Disable default use of bash -x for easier to read output in the log
+        shell: bash
         run: |
           echo '${{ toJSON(matrix) }}'
 
+      - name: Verify inputs
+        id: verify
+        run: |
           MODE="${{ matrix.mode }}"
 
           case ${MODE} in

--- a/docs/key_concepts_and_config.md
+++ b/docs/key_concepts_and_config.md
@@ -128,3 +128,7 @@ _**Known issue:** [Inconsistent Rust compiler version](https://github.com/NLnetL
 By default temporary and final produced artifacts are named under the assumption that no other workflow jobs exist that also upload artifacts and thus may cause artifact name conflicts.
 
 If necessary the `artifact_prefix` worjflow string input can be used to specify a prefix that will be added to every GitHub actions artifact uploaded by Ploutos.
+
+## Strict mode
+
+Some actions performed by Ploutos can result in warnings or errors that are potentially spurious, that is to say that just because Lintian or rpmlint or some other tool reports a problem does not mean to say that we should consider it fatal. For such cases Ploutos by default includes the output of the tools in the log, and in some cases raises warnings in the workflow log, but won't fail the workflow run. If needed by setting the `strict_mode` workflow input to `true` you can force Ploutos to be stricter in some cases than it would normally be.

--- a/docs/os_packaging.md
+++ b/docs/os_packaging.md
@@ -165,6 +165,7 @@ Both `cargo-deb` and `cargo-generate-rpm` have a `variant` feature. Ploutos will
 | `deb_extra_build_packages` | string | No | A space separated set of additional Debian packages to install in the build host when (not cross) compiling. |
 | `deb_apt_key_url` | string | No* | The URL of the public key that can be used to verify a signed package if installing using `deb_apt_source`. Defaults to the NLnet Labs package repository key URL. |
 | `deb_apt_source` | string | No* | A line or lines to write to an APT `/etc/apt/sources.list.d/` file, or the relative path to such a file to install. Used when `mode` of `package_test_rules` is `upgrade-from-published`. Defaults to the NLnet Labs package installation settings. |
+| `deb_extra_lintian_args` | string | No | A space separated set of additional command line arguments to pass to the Debian Lintian package linting tool. Useful to suppress errors you wish to ignore or to supress warnings when `strict_mode` is set to `true`. |
 | `rpm_extra_build_packages` | string | No | A space separated set of additional RPM packages to install in the build host when (not cross) compiling. |
 | `rpm_scriptlets_path` | string | No | The path to a TOML file defining one or more of the `pre_install_script`, `pre_uninstall_script`, `post_install_script` and/or `post_uninstall_script` `cargo-generate-rpm` settings. |
 | `rpm_yum_key_url` | string | No* | The URL of the public key that can be used to verify a signed package if installing using `rpm_yum_repo`. Defaults to the NLnet Labs package repository key URL. |


### PR DESCRIPTION
This PR:
- Adds an optional `strict_mode` boolean workflow input that defaults to false. When true it will fail in certain cases where potentially spurious issues are permitted. Currently this only makes Lintian fail on warnings, where supported.
- Adds an optional `package_build_rules` matrix key `deb_extra_lintian_args` which users can supply to, for example, suppress certain tags that Lintian flags as warnings. As the Lintian check names and set of checks changes by Lintian version the user needs to control this per O/S and O/S release.
- Extends matrix jobs with a "Print matrix" step that prints the matrix input they actually received.
- Fixes #38 which is caused by the JQ syntax used being incompatible with older JQ.
- Suppresses Lintian warning about running as root.

Release checklist:
- [x] 1. Create a branch in the RELEASE repo, let's call this the RELEASE branch.
- [x] 2. Change RPM_MACROS_URL in the workflow to point to the new RELEASE branch.
- [x] 3. Create a PR in the RELEASE repo for the RELEASE branch.
- [x] 4. Create a matching branch in the TEST repo, let's call this the TEST branch.
- [x] 5. Make the desired changes to the RELEASE branch.
- [x] 6. In the TEST branch modify `.github/workflows/pkg.yml` so that instead of referring to `pkg-rust.yml@vX` it refers to `pkg-rust.yml@<Git ref of HEAD commit on the TEST branch>` or `pkg-rust.yml@<test branch name>`.
- [x] 7. Create a PR in the `.gihub-testing` repository from the TEST branch to `main`, let's call this the TEST PR.
- [x] 8. Repeat steps 4 and 5 until the the `Packaging` workflow run in the TEST PR passes and behaves as desired.
- [x] 9. Merge the TEST PR to the `main` branch.
- [x] 10. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo against the `main` branch passes and behaves as desired. If not, repeat steps 4-9 until the new TEST PR passes and behaves as desired.
- [x] 11. Create a release tag in the TEST repo with the same release tag as will be used in the RELEASE repo, e.g. v1.2.3. _**Note:** Remember to respect semantic versioning, i.e. if the changes being made are not backward compatible you will need to bump the MAJOR version (in MAJOR.MINOR.PATCH) **and** any workflows that invoke the reusable workflow will need to be **manually edited** to refer to the new MAJOR version._
- [x] 12. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo passes against the newly created release tag passes and behaves as desired. If not, delete the release tag **in the TEST repo** and repeat steps 4-11 until the new TEST PR passes and behaves as desired.
- [x] 13. Merge the RELEASE PR to the `main` branch.
- [ ] 14. Change RPM_MACROS_URL in the workflow to point to vX.Y.Z tag (that you are about to create).
- [ ] 15. Create the new release vX.Y.Z tag in the RELEASE repo.
- [ ] 16. Update the vX tag in the RELEASE repo to point to the new vX.Y.Z tag.
- [ ] 17. Edit `.github/workflows/pkg.yml` in the `main` branch of the TEST repo to refer again to `@vX`.
- [ ] 18. Verify that the `Packaging` action in the TEST repo against the `main` branch passes and works as desired.
- [ ] 19. (optional) If the MAJOR version was changed, update affected repositories that use the reusable workflow to use the new MAJOR version, including adjusting to any breaking changes introduced by the MAJOR version change.