### PR TITLE
v5.0.2

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -359,8 +359,8 @@ jobs:
           # Exclude debian:stretch because the LXC image is no longer available
           if [[ "${JSON}" != "{}" ]]; then
             CONTROL_JSON=$(echo ${JSON} | jq -c)
-            MODIFIED_JSON=$(echo ${JSON} | jq -c 'del(.image[] | select(. == "debian:stretch")) | del(.include[] | select(.image == "debian:stretch"))')
-            MODIFIED_JSON=$(echo ${MODIFIED_JSON} | jq -c 'del(.include[] | select(.os == "debian:stretch"))')
+            MODIFIED_JSON=$(echo ${JSON} | jq -c 'del(.image[]? | select(. == "debian:stretch")) | del(.include[]? | select(.image == "debian:stretch"))')
+            MODIFIED_JSON=$(echo ${MODIFIED_JSON} | jq -c 'del(.include[]? | select(.os == "debian:stretch"))')
             if [[ "${CONTROL_JSON}" != "${MODIFIED_JSON}" ]]; then
               echo "::warning::Removed debian:stretch image from package_test_rules because the LXC image no longer exists"
               JSON="${MODIFIED_JSON}"
@@ -370,7 +370,7 @@ jobs:
           # Exclude non-x86_64 targets as we only run the tests on x86-64 GitHub runners
           if [[ "${JSON}" != "{}" ]]; then
             CONTROL_JSON=$(echo ${JSON} | jq -c)
-            MODIFIED_JSON=$(echo ${JSON} | jq -c 'del(.target[] | select(. != "x86_64")) | del(.include[] | select(.target != "x86_64" and .target != null))')
+            MODIFIED_JSON=$(echo ${JSON} | jq -c 'del(.target[]? | select(. != "x86_64")) | del(.include[]? | select(.target != "x86_64" and .target != null))')
             if [[ "${CONTROL_JSON}" != "${MODIFIED_JSON}" ]]; then
               echo "::warning::Removed non-x86_64 targets from package_test_rules because testing is only supported for x86_64 targets"
               JSON="${MODIFIED_JSON}"

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -336,7 +336,7 @@ jobs:
           # would be mostly identical to package_build_rules. If we don't remove this we end up causing duplicate Build
           # jobs to be spawned for each different test mode (fresh-install vs upgrade-from-published) which for the
           # pkb job are identical and thus pointless waste and just plain confusing.
-          PACKAGE_BUILD_RULES_PROCESSED_JSON=$(echo ${PACKAGE_BUILD_RULES_RAW_JSON} | jq -c 'del(.mode)')
+          PACKAGE_BUILD_RULES_PROCESSED_JSON=$(echo ${PACKAGE_BUILD_RULES_RAW_JSON} | jq -c 'del(.mode)' | del(.include[]?.mode)')
 
           echo "package_build_rules<<END_OF_PACKAGE_BUILD_RULES" >> $GITHUB_OUTPUT
           echo ${PACKAGE_BUILD_RULES_PROCESSED_JSON} | jq >> $GITHUB_OUTPUT

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -336,7 +336,7 @@ jobs:
           # would be mostly identical to package_build_rules. If we don't remove this we end up causing duplicate Build
           # jobs to be spawned for each different test mode (fresh-install vs upgrade-from-published) which for the
           # pkb job are identical and thus pointless waste and just plain confusing.
-          PACKAGE_BUILD_RULES_PROCESSED_JSON=$(echo ${PACKAGE_BUILD_RULES_RAW_JSON} | jq -c 'del(.mode)' | del(.include[]?.mode)')
+          PACKAGE_BUILD_RULES_PROCESSED_JSON=$(echo ${PACKAGE_BUILD_RULES_RAW_JSON} | jq -c 'del(.mode) | del(.include[]?.mode)')
 
           echo "package_build_rules<<END_OF_PACKAGE_BUILD_RULES" >> $GITHUB_OUTPUT
           echo ${PACKAGE_BUILD_RULES_PROCESSED_JSON} | jq >> $GITHUB_OUTPUT

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -306,7 +306,6 @@ jobs:
             echo "::warning::The 'cross_build_rules' input is deprecated. Cross build targets will be determined automatically."
           fi
 
-          echo "docker_build_rules<<END_OF_DOCKER_BUILD_RULES" >> $GITHUB_OUTPUT
           read -r -d '' DOCKER_BUILD_RULES <<-'EOF'
           ${{ inputs.docker_build_rules }}
           EOF
@@ -316,10 +315,11 @@ jobs:
             JSON=$(echo "${DOCKER_BUILD_RULES}" | yq -I=0 -p=yaml -o=json)
           fi
           JSON=$(echo $JSON | jq '(.. | select(has("crosstarget")?)) |= with_entries(if .key == "crosstarget" then .key = "target" else . end)')
+
+          echo "docker_build_rules<<END_OF_DOCKER_BUILD_RULES" >> $GITHUB_OUTPUT
           echo ${JSON} | jq >> $GITHUB_OUTPUT
           echo 'END_OF_DOCKER_BUILD_RULES' >> $GITHUB_OUTPUT
 
-          echo "package_build_rules<<END_OF_PACKAGE_BUILD_RULES" >> $GITHUB_OUTPUT
           read -r -d '' PACKAGE_BUILD_RULES <<-'EOF'
           ${{ inputs.package_build_rules }}
           EOF
@@ -336,17 +336,17 @@ jobs:
           # pkb job are identical and thus pointless waste and just plain confusing.
           MODIFIED_JSON=$(echo ${JSON} | jq -c 'del(.mode)')
 
+          echo "package_build_rules<<END_OF_PACKAGE_BUILD_RULES" >> $GITHUB_OUTPUT
           echo ${MODIFIED_JSON} | jq >> $GITHUB_OUTPUT
           echo 'END_OF_PACKAGE_BUILD_RULES' >> $GITHUB_OUTPUT
 
-          echo "package_test_rules<<END_OF_PACKAGE_TEST_RULES" >> $GITHUB_OUTPUT
           read -r -d '' PACKAGE_TEST_RULES <<-'EOF'
           ${{ inputs.package_test_rules }}
           EOF
           if [[ "${PACKAGE_TEST_RULES}" == 'none' ]]; then
             JSON='{}'
           elif [[ "${PACKAGE_TEST_RULES}" == 'use_package_build_rules' ]]; then
-            JSON=$(yq "${PACKAGE_TEST_RULES}" -I=0 -p=yaml -o=json)
+            JSON=$(yq "${PACKAGE_BUILD_RULES}" -I=0 -p=yaml -o=json)
           elif [[ -f "${PACKAGE_TEST_RULES}" ]]; then
             JSON=$(yq "${PACKAGE_TEST_RULES}" -I=0 -p=yaml -o=json)
           else
@@ -374,6 +374,7 @@ jobs:
             fi
           fi
 
+          echo "package_test_rules<<END_OF_PACKAGE_TEST_RULES" >> $GITHUB_OUTPUT
           echo ${JSON} | jq >> $GITHUB_OUTPUT
           echo 'END_OF_PACKAGE_TEST_RULES' >> $GITHUB_OUTPUT
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1656,7 +1656,7 @@ jobs:
       published: ${{ steps.publish.conclusion == 'success' }}
     # Use of always() here ensures that even if the _cross_ job (note: not the 'docker' job) is skipped we will still run.
     # I wouldn't expect this to be needed but since the cross job was made conditional we seem to need this.
-    if: ${{ always() && fromJSON(needs.prepare.outputs.has_docker_secrets) == true && (contains(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main') }}
+    if: ${{ always() && fromJSON(needs.docker.outputs.published) == true && fromJSON(needs.prepare.outputs.has_docker_secrets) == true && (contains(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-20.04
     steps:
       - name: Log into Docker Hub

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -298,6 +298,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      # TODO: extract common code into helper functions
       - name: Pre-process rules
         id: pre_process_rules
         run: |
@@ -306,20 +307,26 @@ jobs:
           fi
 
           echo "docker_build_rules<<END_OF_DOCKER_BUILD_RULES" >> $GITHUB_OUTPUT
-          if [[ -f '${{ inputs.docker_build_rules }}' ]]; then
-            JSON=$(yq '${{ inputs.docker_build_rules }}' -I=0 -p=yaml -o=json)
+          read -r -d '' DOCKER_BUILD_RULES <<-'EOF'
+          ${{ inputs.docker_build_rules }}
+          EOF
+          if [[ -f "${DOCKER_BUILD_RULES}" ]]; then
+            JSON=$(yq "${DOCKER_BUILD_RULES}" -I=0 -p=yaml -o=json)
           else
-            JSON=$(echo '${{ inputs.docker_build_rules }}' | yq -I=0 -p=yaml -o=json)
+            JSON=$(echo "${DOCKER_BUILD_RULES}" | yq -I=0 -p=yaml -o=json)
           fi
           JSON=$(echo $JSON | jq '(.. | select(has("crosstarget")?)) |= with_entries(if .key == "crosstarget" then .key = "target" else . end)')
           echo ${JSON} | jq >> $GITHUB_OUTPUT
           echo 'END_OF_DOCKER_BUILD_RULES' >> $GITHUB_OUTPUT
 
           echo "package_build_rules<<END_OF_PACKAGE_BUILD_RULES" >> $GITHUB_OUTPUT
-          if [[ -f '${{ inputs.package_build_rules }}' ]]; then
-            JSON=$(yq '${{ inputs.package_build_rules }}' -I=0 -p=yaml -o=json)
+          read -r -d '' PACKAGE_BUILD_RULES <<-'EOF'
+          ${{ inputs.package_build_rules }}
+          EOF
+          if [[ -f "${PACKAGE_BUILD_RULES}" ]]; then
+            JSON=$(yq "${PACKAGE_BUILD_RULES}" -I=0 -p=yaml -o=json)
           else
-            JSON=$(echo '${{ inputs.package_build_rules }}' | yq -I=0 -p=yaml -o=json)
+            JSON=$(echo "${PACKAGE_BUILD_RULES}" | yq -I=0 -p=yaml -o=json)
           fi
 
           # Don't permute the build job over variables intended only for use by the pkg-test job but which were supplied
@@ -333,14 +340,17 @@ jobs:
           echo 'END_OF_PACKAGE_BUILD_RULES' >> $GITHUB_OUTPUT
 
           echo "package_test_rules<<END_OF_PACKAGE_TEST_RULES" >> $GITHUB_OUTPUT
-          if [[ '${{ inputs.package_test_rules }}' == 'none' ]]; then
+          read -r -d '' PACKAGE_TEST_RULES <<-'EOF'
+          ${{ inputs.package_test_rules }}
+          EOF
+          if [[ "${PACKAGE_TEST_RULES}" == 'none' ]]; then
             JSON='{}'
-          elif [[ '${{ inputs.package_test_rules }}' == 'use_package_build_rules' ]]; then
-            JSON=$(yq '${{ inputs.package_build_rules }}' -I=0 -p=yaml -o=json)
-          elif [[ -f '${{ inputs.package_test_rules }}' ]]; then
-            JSON=$(yq '${{ inputs.package_test_rules }}' -I=0 -p=yaml -o=json)
+          elif [[ "${PACKAGE_TEST_RULES}" == 'use_package_build_rules' ]]; then
+            JSON=$(yq "${PACKAGE_TEST_RULES}" -I=0 -p=yaml -o=json)
+          elif [[ -f "${PACKAGE_TEST_RULES}" ]]; then
+            JSON=$(yq "${PACKAGE_TEST_RULES}" -I=0 -p=yaml -o=json)
           else
-            JSON=$(echo '${{ inputs.package_test_rules }}' | yq -I=0 -p=yaml -o=json)
+            JSON=$(echo "${PACKAGE_TEST_RULES}" | yq -I=0 -p=yaml -o=json)
           fi
 
           # Exclude debian:stretch because the LXC image is no longer available

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1656,7 +1656,7 @@ jobs:
       published: ${{ steps.publish.conclusion == 'success' }}
     # Use of always() here ensures that even if the _cross_ job (note: not the 'docker' job) is skipped we will still run.
     # I wouldn't expect this to be needed but since the cross job was made conditional we seem to need this.
-    if: ${{ always() && needs.docker.outputs.published == true && fromJSON(needs.prepare.outputs.has_docker_secrets) == true && (contains(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main') }}
+    if: ${{ always() && needs.prepare.outputs.docker_build_rules != '{}' && fromJSON(needs.prepare.outputs.has_docker_secrets) == true && (contains(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-20.04
     steps:
       - name: Log into Docker Hub

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1656,7 +1656,7 @@ jobs:
       published: ${{ steps.publish.conclusion == 'success' }}
     # Use of always() here ensures that even if the _cross_ job (note: not the 'docker' job) is skipped we will still run.
     # I wouldn't expect this to be needed but since the cross job was made conditional we seem to need this.
-    if: ${{ always() && fromJSON(needs.docker.outputs.published) == true && fromJSON(needs.prepare.outputs.has_docker_secrets) == true && (contains(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main') }}
+    if: ${{ always() && needs.docker.outputs.published == true && fromJSON(needs.prepare.outputs.has_docker_secrets) == true && (contains(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-20.04
     steps:
       - name: Log into Docker Hub

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -346,7 +346,7 @@ jobs:
           if [[ "${PACKAGE_TEST_RULES}" == 'none' ]]; then
             JSON='{}'
           elif [[ "${PACKAGE_TEST_RULES}" == 'use_package_build_rules' ]]; then
-            JSON=$(yq "${PACKAGE_BUILD_RULES}" -I=0 -p=yaml -o=json)
+            JSON=$(echo "${PACKAGE_BUILD_RULES}" | yq -I=0 -p=yaml -o=json)
           elif [[ -f "${PACKAGE_TEST_RULES}" ]]; then
             JSON=$(yq "${PACKAGE_TEST_RULES}" -I=0 -p=yaml -o=json)
           else

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1025,7 +1025,7 @@ jobs:
             # command line argument.
             if [[ "${{ inputs.rpm_scriptlets_path }}" != "" ]]; then
               # Download the RPM systemd macros shell functions file fragment
-              SYSTEMD_RPM_MACROS_URL="https://raw.githubusercontent.com/NLnetLabs/ploutos/v5.0.1/fragments/macros.systemd.sh"
+              SYSTEMD_RPM_MACROS_URL="https://raw.githubusercontent.com/NLnetLabs/ploutos/v5.0.2/fragments/macros.systemd.sh"
               SYSTEMD_RPM_MACROS_FILE="/tmp/systemd_rpm_macros"
               curl --proto '=https' --tlsv1.2 --fail --output ${SYSTEMD_RPM_MACROS_FILE} ${SYSTEMD_RPM_MACROS_URL}
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -306,9 +306,10 @@ jobs:
             echo "::warning::The 'cross_build_rules' input is deprecated. Cross build targets will be determined automatically."
           fi
 
-          read -r -d '' DOCKER_BUILD_RULES <<-'EOF'
+          DOCKER_BUILD_RULES=$(cat <<'EOF'
           ${{ inputs.docker_build_rules }}
           EOF
+          )
           if [[ -f "${DOCKER_BUILD_RULES}" ]]; then
             JSON=$(yq "${DOCKER_BUILD_RULES}" -I=0 -p=yaml -o=json)
           else
@@ -320,9 +321,10 @@ jobs:
           echo ${JSON} | jq >> $GITHUB_OUTPUT
           echo 'END_OF_DOCKER_BUILD_RULES' >> $GITHUB_OUTPUT
 
-          read -r -d '' PACKAGE_BUILD_RULES <<-'EOF'
+          PACKAGE_BUILD_RULES=$(cat <<'EOF'
           ${{ inputs.package_build_rules }}
           EOF
+          )
           if [[ -f "${PACKAGE_BUILD_RULES}" ]]; then
             JSON=$(yq "${PACKAGE_BUILD_RULES}" -I=0 -p=yaml -o=json)
           else
@@ -340,9 +342,10 @@ jobs:
           echo ${MODIFIED_JSON} | jq >> $GITHUB_OUTPUT
           echo 'END_OF_PACKAGE_BUILD_RULES' >> $GITHUB_OUTPUT
 
-          read -r -d '' PACKAGE_TEST_RULES <<-'EOF'
+          PACKAGE_TEST_RULES=$(cat <<'EOF'
           ${{ inputs.package_test_rules }}
           EOF
+          )
           if [[ "${PACKAGE_TEST_RULES}" == 'none' ]]; then
             JSON='{}'
           elif [[ "${PACKAGE_TEST_RULES}" == 'use_package_build_rules' ]]; then

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -326,9 +326,9 @@ jobs:
           EOF
           )
           if [[ -f "${PACKAGE_BUILD_RULES}" ]]; then
-            JSON=$(yq "${PACKAGE_BUILD_RULES}" -I=0 -p=yaml -o=json)
+            PACKAGE_BUILD_RULES_RAW_JSON=$(yq "${PACKAGE_BUILD_RULES}" -I=0 -p=yaml -o=json)
           else
-            JSON=$(echo "${PACKAGE_BUILD_RULES}" | yq -I=0 -p=yaml -o=json)
+            PACKAGE_BUILD_RULES_RAW_JSON=$(echo "${PACKAGE_BUILD_RULES}" | yq -I=0 -p=yaml -o=json)
           fi
 
           # Don't permute the build job over variables intended only for use by the pkg-test job but which were supplied
@@ -336,10 +336,10 @@ jobs:
           # would be mostly identical to package_build_rules. If we don't remove this we end up causing duplicate Build
           # jobs to be spawned for each different test mode (fresh-install vs upgrade-from-published) which for the
           # pkb job are identical and thus pointless waste and just plain confusing.
-          MODIFIED_JSON=$(echo ${JSON} | jq -c 'del(.mode)')
+          PACKAGE_BUILD_RULES_PROCESSED_JSON=$(echo ${PACKAGE_BUILD_RULES_RAW_JSON} | jq -c 'del(.mode)')
 
           echo "package_build_rules<<END_OF_PACKAGE_BUILD_RULES" >> $GITHUB_OUTPUT
-          echo ${MODIFIED_JSON} | jq >> $GITHUB_OUTPUT
+          echo ${PACKAGE_BUILD_RULES_PROCESSED_JSON} | jq >> $GITHUB_OUTPUT
           echo 'END_OF_PACKAGE_BUILD_RULES' >> $GITHUB_OUTPUT
 
           PACKAGE_TEST_RULES=$(cat <<'EOF'
@@ -347,38 +347,39 @@ jobs:
           EOF
           )
           if [[ "${PACKAGE_TEST_RULES}" == 'none' ]]; then
-            JSON='{}'
+            PACKAGE_TEST_RULES_RAW_JSON='{}'
           elif [[ "${PACKAGE_TEST_RULES}" == 'use_package_build_rules' ]]; then
-            JSON=$(echo "${PACKAGE_BUILD_RULES}" | yq -I=0 -p=yaml -o=json)
+            PACKAGE_TEST_RULES_RAW_JSON="${PACKAGE_BUILD_RULES_RAW_JSON}"
           elif [[ -f "${PACKAGE_TEST_RULES}" ]]; then
-            JSON=$(yq "${PACKAGE_TEST_RULES}" -I=0 -p=yaml -o=json)
+            PACKAGE_TEST_RULES_RAW_JSON=$(yq "${PACKAGE_TEST_RULES}" -I=0 -p=yaml -o=json)
           else
-            JSON=$(echo "${PACKAGE_TEST_RULES}" | yq -I=0 -p=yaml -o=json)
+            PACKAGE_TEST_RULES_RAW_JSON=$(echo "${PACKAGE_TEST_RULES}" | yq -I=0 -p=yaml -o=json)
           fi
 
           # Exclude debian:stretch because the LXC image is no longer available
-          if [[ "${JSON}" != "{}" ]]; then
-            CONTROL_JSON=$(echo ${JSON} | jq -c)
-            MODIFIED_JSON=$(echo ${JSON} | jq -c 'del(.image[]? | select(. == "debian:stretch")) | del(.include[]? | select(.image == "debian:stretch"))')
+          PACKAGE_TEST_RULES_PROCESSED_JSON="${PACKAGE_TEST_RULES_RAW_JSON}"
+          if [[ "${PACKAGE_TEST_RULES_RAW_JSON}" != "{}" ]]; then
+            CONTROL_JSON=$(echo ${PACKAGE_TEST_RULES_RAW_JSON} | jq -c)
+            MODIFIED_JSON=$(echo ${PACKAGE_TEST_RULES_RAW_JSON} | jq -c 'del(.image[]? | select(. == "debian:stretch")) | del(.include[]? | select(.image == "debian:stretch"))')
             MODIFIED_JSON=$(echo ${MODIFIED_JSON} | jq -c 'del(.include[]? | select(.os == "debian:stretch"))')
             if [[ "${CONTROL_JSON}" != "${MODIFIED_JSON}" ]]; then
               echo "::warning::Removed debian:stretch image from package_test_rules because the LXC image no longer exists"
-              JSON="${MODIFIED_JSON}"
+              PACKAGE_TEST_RULES_PROCESSED_JSON="${MODIFIED_JSON}"
             fi
           fi
 
           # Exclude non-x86_64 targets as we only run the tests on x86-64 GitHub runners
-          if [[ "${JSON}" != "{}" ]]; then
-            CONTROL_JSON=$(echo ${JSON} | jq -c)
-            MODIFIED_JSON=$(echo ${JSON} | jq -c 'del(.target[]? | select(. != "x86_64")) | del(.include[]? | select(.target != "x86_64" and .target != null))')
+          if [[ "${PACKAGE_TEST_RULES_PROCESSED_JSON}" != "{}" ]]; then
+            CONTROL_JSON=$(echo ${PACKAGE_TEST_RULES_PROCESSED_JSON} | jq -c)
+            MODIFIED_JSON=$(echo ${PACKAGE_TEST_RULES_PROCESSED_JSON} | jq -c 'del(.target[]? | select(. != "x86_64")) | del(.include[]? | select(.target != "x86_64" and .target != null))')
             if [[ "${CONTROL_JSON}" != "${MODIFIED_JSON}" ]]; then
               echo "::warning::Removed non-x86_64 targets from package_test_rules because testing is only supported for x86_64 targets"
-              JSON="${MODIFIED_JSON}"
+              PACKAGE_TEST_RULES_PROCESSED_JSON="${MODIFIED_JSON}"
             fi
           fi
 
           echo "package_test_rules<<END_OF_PACKAGE_TEST_RULES" >> $GITHUB_OUTPUT
-          echo ${JSON} | jq >> $GITHUB_OUTPUT
+          echo ${PACKAGE_TEST_RULES_PROCESSED_JSON} | jq >> $GITHUB_OUTPUT
           echo 'END_OF_PACKAGE_TEST_RULES' >> $GITHUB_OUTPUT
 
       - name: Determine cross build rules


### PR DESCRIPTION
Various fixes:
- Prevent unwanted interpolation of YAML content.
- Handle null in JQ pipelines when pre-processing matrix rules.
- Don't attempt Docker Manifest publication unless Docker images have been published.

Successful test runs can be seen here:
- dev branch: https://github.com/NLnetLabs/ploutos-testing/actions/runs/3530551508
- main branch: https://github.com/NLnetLabs/ploutos-testing/actions/runs/3530991898
- release tag: https://github.com/NLnetLabs/ploutos-testing/actions/runs/3531171450

Release checklist:
- [x] 1. Create a branch in the RELEASE repo, let's call this the RELEASE branch.
- [x] 2. Change RPM_MACROS_URL in the workflow to point to the new RELEASE branch.
- [x] 3. Create a PR in the RELEASE repo for the RELEASE branch.
- [x] 4. Create a matching branch in the TEST repo, let's call this the TEST branch.
- [x] 5. Make the desired changes to the RELEASE branch.
- [x] 6. In the TEST branch modify `.github/workflows/pkg.yml` so that instead of referring to `pkg-rust.yml@vX` it refers to `pkg-rust.yml@<Git ref of HEAD commit on the TEST branch>` or `pkg-rust.yml@<test branch name>`.
- [x] 7. Create a PR in the `.gihub-testing` repository from the TEST branch to `main`, let's call this the TEST PR.
- [x] 8. Repeat steps 4 and 5 until the the `Packaging` workflow run in the TEST PR passes and behaves as desired.
- [x] 9. Merge the TEST PR to the `main` branch.
- [x] 10. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo against the `main` branch passes and behaves as desired. If not, repeat steps 4-9 until the new TEST PR passes and behaves as desired.
- [x] 11. Create a release tag in the TEST repo with the same release tag as will be used in the RELEASE repo, e.g. v1.2.3. _**Note:** Remember to respect semantic versioning, i.e. if the changes being made are not backward compatible you will need to bump the MAJOR version (in MAJOR.MINOR.PATCH) **and** any workflows that invoke the reusable workflow will need to be **manually edited** to refer to the new MAJOR version._
- [x] 12. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo passes against the newly created release tag passes and behaves as desired. If not, delete the release tag **in the TEST repo** and repeat steps 4-11 until the new TEST PR passes and behaves as desired.
- [x] 13. Merge the RELEASE PR to the `main` branch.
- [ ] 14. Change RPM_MACROS_URL in the workflow to point to vX.Y.Z tag (that you are about to create).
- [ ] 15. Create the new release vX.Y.Z tag in the RELEASE repo.
- [ ] 16. Update the vX tag in the RELEASE repo to point to the new vX.Y.Z tag.
- [ ] 17. Edit `.github/workflows/pkg.yml` in the `main` branch of the TEST repo to refer again to `@vX`.
- [ ] 18. Verify that the `Packaging` action in the TEST repo against the `main` branch passes and works as desired.
- [ ] 19. (optional) If the MAJOR version was changed, update affected repositories that use the reusable workflow to use the new MAJOR version, including adjusting to any breaking changes introduced by the MAJOR version change.