### PR TITLE
v5.0.3

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1225,8 +1225,8 @@ jobs:
             # See: https://github.com/cat-in-136/cargo-generate-rpm/issues/20
             case ${OS_REL} in
               7)
-                mkdir ~/.config
-                cat <<'EOF' >~/.config/rpmlint
+                mkdir $HOME/.config
+                cat <<'EOF' >$HOME/.config/rpmlint
         from Config import *
         addFilter("E: no-binary")
         addFilter("E: no-buildhost-tag")
@@ -1239,8 +1239,8 @@ jobs:
                   EXTRA_RPMLINT_ARGS="${EXTRA_RPMLINT_ARGS} --strict"
                 fi
 
-                mkdir ~/.config
-                cat <<'EOF' >~/.config/rpmlint
+                mkdir $HOME/.config
+                cat <<'EOF' >$HOME/.config/rpmlint
         addFilter("E: no-binary")
         addFilter("E: no-buildhost-tag")
         addFilter("E: no-changelogname-tag")
@@ -1249,7 +1249,7 @@ jobs:
         addFilter("E: no-group-tag")
         EOF
 
-                EXTRA_RPMLINT_ARGS="${EXTRA_RPMLINT_ARGS} --rpmlintrc ~/.config/rpmlint"
+                EXTRA_RPMLINT_ARGS="${EXTRA_RPMLINT_ARGS} --rpmlintrc $HOME/.config/rpmlint"
                 ;;
             esac
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1207,31 +1207,40 @@ jobs:
             # cargo generate-rpm creates RPMs that rpmlint considers to have errors so don't use the rpmlint exit code
             # otherwise we will always abort the workflow.
 
-            if [[ "${OS_REL}" == "7" ]]; then
-              # The no-binary check is faulty on older rpmlint versions and the only way to disable the check is by 
-              # writing a config file to disk. Also filter out the no-buildhost-tag and no-changelogname-tag errors as
-              # we have no way to add the missing tags. At the time of writing versions encountered were:
-              #    centos:7 Docker image    : rpmlint 1.5
-              #    rockylinux:8 Docker image: rpmlint 1.10
-              # Both wrongly raise "E: no-binary"
-              #
-              # CentOS / RockyLinux 8 supports rpmlint 2.x via python3-pip, so we can use the newer version instead,
-              # but this can't be installed on CentOS 7 due to a missing rpm-python3 RPM bindings package needed by pip3
-              # install.
-              #
-              # See: https://github.com/rpm-software-management/rpmlint/blob/rpmlint-1.4/README#L39
-              # See: https://github.com/cat-in-136/cargo-generate-rpm/issues/20
-              mkdir ~/.config
-              cat <<'EOF' >~/.config/rpmlint
+            EXTRA_RPMLINT_ARGS="${{ matrix.rpm_extra_rpmlint_args }}"
+            case ${OS_REL} in
+              7)
+                # The no-binary check is faulty on older rpmlint versions and the only way to disable the check is by 
+                # writing a config file to disk. Also filter out the no-buildhost-tag and no-changelogname-tag errors as
+                # we have no way to add the missing tags. At the time of writing versions encountered were:
+                #    centos:7 Docker image    : rpmlint 1.5
+                #    rockylinux:8 Docker image: rpmlint 1.10
+                # Both wrongly raise "E: no-binary"
+                #
+                # CentOS / RockyLinux 8 supports rpmlint 2.x via python3-pip, so we can use the newer version instead,
+                # but this can't be installed on CentOS 7 due to a missing rpm-python3 RPM bindings package needed by pip3
+                # install.
+                #
+                # See: https://github.com/rpm-software-management/rpmlint/blob/rpmlint-1.4/README#L39
+                # See: https://github.com/cat-in-136/cargo-generate-rpm/issues/20
+                mkdir ~/.config
+                cat <<'EOF' >~/.config/rpmlint
         from Config import *
         addFilter("E: no-binary")
         addFilter("E: no-buildhost-tag")
         addFilter("E: no-changelogname-tag")
         EOF
-            fi
+                ;;
+
+              8)
+                if [[ "${{ inputs.strict_mode }}" == "true" ]]; then
+                  EXTRA_RPMLINT_ARGS="${EXTRA_RPMLINT_ARGS} --strict"
+                fi
+                ;;
+            esac
 
             rpmlint --version
-            rpmlint target/generate-rpm/*.rpm
+            rpmlint ${EXTRA_RPMLINT_ARGS} target/generate-rpm/*.rpm
             ;;
         esac
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1268,7 +1268,7 @@ jobs:
             esac
 
             for CHECK_NAME in ${{ matrix.rpm_rpmlint_check_filters }}; do
-              echo 'setBadness('${CHECK_NAME}', 0)' >> ${LINTER_CONFIG_PATH}
+              echo "setBadness('${CHECK_NAME}', 0)" >> ${LINTER_CONFIG_PATH}
             done
 
             cat ${LINTER_CONFIG_PATH}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1215,6 +1215,7 @@ jobs:
             #    centos:7 Docker image    : rpmlint 1.5
             #    rockylinux:8 Docker image: rpmlint 1.10
             #    rockylinux:8 Docker image: rpmlint 2.4.0 (via pip3 install rpmlint)
+            #    fedora:37 Docker image:    rpmlint 2.2.0
             #
             # CentOS / RockyLinux 8 supports rpmlint 2.x via python3-pip, so we can use the newer version instead, but
             # this can't be installed on CentOS 7 due to a missing rpm-python3 RPM bindings package needed by pip3
@@ -1239,8 +1240,9 @@ jobs:
                   EXTRA_RPMLINT_ARGS="${EXTRA_RPMLINT_ARGS} --strict"
                 fi
 
+                LINTER_CONFIG_PATH="$HOME/.config/rpmlint"
                 mkdir $HOME/.config
-                cat <<'EOF' >$HOME/.config/rpmlint
+                cat <<'EOF' >${LINTER_CONFIG_PATH}
         addFilter("E: no-binary")
         addFilter("E: no-buildhost-tag")
         addFilter("E: no-changelogname-tag")
@@ -1249,7 +1251,17 @@ jobs:
         addFilter("E: no-group-tag")
         EOF
 
-                EXTRA_RPMLINT_ARGS="${EXTRA_RPMLINT_ARGS} --rpmlintrc $HOME/.config/rpmlint"
+                # rpmlint 2.x requires that we explicitly tell it where the config file is, and the pip installed
+                # version doesn't come with any existing list of valid licenses so we have to install one ourselves.
+                # With rpmlint 1.x, or rpmlint 2.x installed from O/S package (e.g. on fedora:37) the valid license
+                # set is pre-loaded, but that doesn't help us here. If we don't solve this a warning, or error in
+                # strict mode, will be raised about the unknown license used by the RPM being checked (as all
+                # licenses are unknown!).
+                LICENSES_CONF_URL="https://raw.githubusercontent.com/rpm-software-management/rpmlint/2.4.0/configs/Fedora/licenses.toml"
+                LICENSES_CONF_PATH="$HOME/.config/rpmlint-licenses.conf"
+                curl --proto '=https' --tlsv1.2 --fail --output ${LICENSES_CONF_PATH} ${LICENSES_CONF_URL}
+
+                EXTRA_RPMLINT_ARGS="${EXTRA_RPMLINT_ARGS} --rpmlintrc ${LINTER_CONFIG_PATH} --config ${LICENSES_CONF_PATH}"
                 ;;
             esac
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -284,6 +284,7 @@ jobs:
   prepare:
     runs-on: ubuntu-22.04
     outputs:
+      cargo_name: ${{ steps.verify.outputs.cargo_name }}
       has_docker_secrets: ${{ steps.verify_inputs.outputs.has_docker_secrets }}
       all_repo_and_tag_pairs: ${{ steps.encode.outputs.all_repo_and_tag_pairs }}
       first_repo_and_tag_pair: ${{ steps.encode.outputs.first_repo_and_tag_pair }}
@@ -497,6 +498,9 @@ jobs:
             echo "has_docker_secrets=false" >> $GITHUB_OUTPUT
           fi
 
+          CARGO_NAME=$(cat Cargo.toml | docker run --rm -i sclevine/yj -tj | jq -r .package.name)
+          echo "cargo_name=${CARGO_NAME}" >> $GITHUB_OUTPUT
+
       - name: Verify Docker credentials
         if: ${{ steps.pre_process_rules.outputs.docker_build_rules != '{}' && fromJSON(steps.verify_inputs.outputs.has_docker_secrets) == true }}
         uses: docker/login-action@v2
@@ -668,6 +672,7 @@ jobs:
         echo '${{ toJSON(matrix) }}'
 
     - name: Verify inputs
+      id: verify
       run: |
         if [[ ! -f Cargo.toml ]]; then
           echo "::error::File 'Cargo.toml' is missing. This workflow is only intended for use with Rust Cargo projects."
@@ -685,8 +690,9 @@ jobs:
         fi
 
         if [[ '${{ matrix.pkg }}' == '' ]]; then
-          echo "::error::Required matrix variable 'pkg' is not defined in package_build_rules."
-          exit 1
+          echo "pkg=${{ needs.prepare.outputs.cargo_name }}" >> $GITHUB_OUTPUT
+        else
+          echo "pkg=${{ matrix.pkg }}" >> $GITHUB_OUTPUT
         fi
 
     - name: Set vars
@@ -773,7 +779,7 @@ jobs:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
-        key: ${{ matrix.image }}-${{ matrix.target }}-${{ matrix.pkg }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ matrix.image }}-${{ matrix.target }}-${{ steps.verify.outputs.pkg }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
     # Speed up tooling installation by only re-downloading and re-building dependent crates if we change the version of
     # the tool that we are using.
@@ -837,7 +843,7 @@ jobs:
     # arguments.
     - name: Create the package
       env:
-        MATRIX_PKG: ${{ matrix.pkg }}
+        MATRIX_PKG: ${{ steps.verify.outputs.pkg }}
         EXTRA_BUILD_ARGS: ${{ matrix.extra_build_args }}
         CROSS_TARGET: ${{ matrix.target }}
       run: |
@@ -1189,7 +1195,7 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@v3
       with:
-        name: ${{ inputs.artifact_prefix }}${{ matrix.pkg }}_${{ env.OS_NAME }}_${{ env.OS_REL }}_${{ matrix.target }}
+        name: ${{ inputs.artifact_prefix }}${{ steps.verify.outputs.pkg }}_${{ env.OS_NAME }}_${{ env.OS_REL }}_${{ matrix.target }}
         path: |
           target/debian/*.deb
           target/generate-rpm/*.rpm
@@ -1235,8 +1241,9 @@ jobs:
         fi
 
         if [[ '${{ matrix.pkg }}' == '' ]]; then
-          echo "::error::Required matrix variable 'pkg' is not defined in package_test_rules."
-          exit 1
+          echo "pkg=${{ needs.prepare.outputs.cargo_name }}" >> $GITHUB_OUTPUT
+        else
+          echo "pkg=${{ matrix.pkg }}" >> $GITHUB_OUTPUT
         fi
 
         if [[ '${{ matrix.mode }}' == '' ]]; then
@@ -1286,7 +1293,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@v3
       with:
-        name: ${{ inputs.artifact_prefix }}${{ matrix.pkg }}_${{ env.OS_NAME }}_${{ env.OS_REL }}_${{ matrix.target }}
+        name: ${{ inputs.artifact_prefix }}${{ steps.verify.outputs.pkg }}_${{ env.OS_NAME }}_${{ env.OS_REL }}_${{ matrix.target }}
 
     - name: Add current user to LXD group
       run: |
@@ -1338,7 +1345,7 @@ jobs:
             ;;
         esac
 
-    - name: Copy the newly built ${{ matrix.pkg }} package into the LXC container
+    - name: Copy the newly built package into the LXC container
       run: |
         case ${OS_NAME} in
           debian|ubuntu)
@@ -1353,7 +1360,7 @@ jobs:
             ;;
         esac
 
-    - name: Install previously published ${{ matrix.pkg }} package
+    - name: Install previously published package
       id: instprev
       if: ${{ steps.verify.outputs.mode == 'upgrade-from-published' }}
       run: |
@@ -1369,12 +1376,12 @@ jobs:
             sg lxd -c "lxc exec testcon -- wget -q ${{ inputs.deb_apt_key_url }} -Oaptkey.asc"
             sg lxd -c "lxc exec testcon -- apt-key add ./aptkey.asc"
             sg lxd -c "lxc exec testcon -- apt-get -y update"
-            sg lxd -c "lxc exec testcon -- apt-get install -y ${{ matrix.pkg }}"
+            sg lxd -c "lxc exec testcon -- apt-get install -y ${{ steps.verify.outputs.pkg }}"
 
             # determine the conffiles, append a harmless line break to each one (so that they are modified) then save
             # the md5sums of the modified files for comparison after upgrade to ensure our edits are not overwritten
-            SAVED_MD5SUMS="/tmp/${{ matrix.pkg }}-conffiles.md5"
-            CONFIFILE_LIST_FILE="/var/lib/dpkg/info/${{ matrix.pkg }}.conffiles"
+            SAVED_MD5SUMS="/tmp/${{ steps.verify.outputs.pkg }}-conffiles.md5"
+            CONFIFILE_LIST_FILE="/var/lib/dpkg/info/${{ steps.verify.outputs.pkg }}.conffiles"
 
             # append a line break to the conffile
             for F in $(sg lxd -c "lxc exec testcon -- cat ${CONFIFILE_LIST_FILE}"); do
@@ -1398,11 +1405,11 @@ jobs:
             fi
             sg lxd -c "lxc exec testcon -- sed -i -e 's/\${OS_NAME}/${OS_NAME}/g' -e 's/\${OS_REL}/${OS_REL}/g' /etc/yum.repos.d/ploutos.repo"
             sg lxd -c "lxc exec testcon -- rpm --import ${{ inputs.rpm_yum_key_url }}"
-            sg lxd -c "lxc exec testcon -- yum install -y ${{ matrix.pkg }}"
+            sg lxd -c "lxc exec testcon -- yum install -y ${{ steps.verify.outputs.pkg }}"
             ;;
         esac
 
-    - name: Install the newly built ${{ matrix.pkg }} package
+    - name: Install the newly built package
       if: ${{ steps.verify.outputs.mode == 'fresh-install' }}
       run: |
         case ${OS_NAME} in
@@ -1416,15 +1423,15 @@ jobs:
             ;;
         esac
 
-    - name: Test the installed ${{ matrix.pkg }} package
+    - name: Test the installed package
       if: ${{ inputs.package_test_scripts_path != '' && steps.verify.outputs.mode == 'fresh-install' }}
       run: |
-        TEST_SCRIPT="$(echo '${{ inputs.package_test_scripts_path }}' | sed -e 's/<package>/${{ matrix.pkg }}/g')"
+        TEST_SCRIPT="$(echo '${{ inputs.package_test_scripts_path }}' | sed -e 's/<package>/${{ steps.verify.outputs.pkg }}/g')"
         sg lxd -c "lxc file push ${TEST_SCRIPT} testcon/tmp/test.sh"
         sg lxd -c "lxc exec testcon -- chmod +x /tmp/test.sh"
         sg lxd -c "lxc exec testcon -- /tmp/test.sh post-install"
 
-    - name: Upgrade from the published ${{ matrix.pkg }} package to the newly built package
+    - name: Upgrade from the published package to the newly built package
       id: upgrade_package
       continue-on-error: true
       if: ${{ steps.verify.outputs.mode == 'upgrade-from-published' }}
@@ -1453,17 +1460,17 @@ jobs:
       run: |
         case ${OS_NAME} in
           debian|ubuntu)
-            SAVED_MD5SUMS="/tmp/${{ matrix.pkg }}-conffiles.md5"
+            SAVED_MD5SUMS="/tmp/${{ steps.verify.outputs.pkg }}-conffiles.md5"
             sg lxd -c "lxc exec testcon -- sh -c '[ ! -f ${SAVED_MD5SUMS} ] || md5sum -c ${SAVED_MD5SUMS}'"
             ;;
           centos)
             ;;
         esac
 
-    - name: Test the upgraded ${{ matrix.pkg }} package
+    - name: Test the upgraded package
       if: ${{ inputs.package_test_scripts_path != '' && steps.verify.outputs.mode == 'upgrade-from-published' }}
       run: |
-        TEST_SCRIPT="$(echo '${{ inputs.package_test_scripts_path }}' | sed -e 's/<package>/${{ matrix.pkg }}/g')"
+        TEST_SCRIPT="$(echo '${{ inputs.package_test_scripts_path }}' | sed -e 's/<package>/${{ steps.verify.outputs.pkg }}/g')"
         sg lxd -c "lxc file push ${TEST_SCRIPT} testcon/tmp/test2.sh"
         sg lxd -c "lxc exec testcon -- chmod +x /tmp/test2.sh"
         sg lxd -c "lxc exec testcon -- /tmp/test2.sh post-upgrade"
@@ -1472,10 +1479,10 @@ jobs:
       run: |
         case ${OS_NAME} in
           debian|ubuntu)
-            sg lxd -c "lxc exec testcon -- apt-get -y remove ${{ matrix.pkg }}"
+            sg lxd -c "lxc exec testcon -- apt-get -y remove ${{ steps.verify.outputs.pkg }}"
             ;;
           centos)
-            sg lxd -c "lxc exec testcon -- yum remove -y ${{ matrix.pkg }}" 2>&1 | tee remove.log
+            sg lxd -c "lxc exec testcon -- yum remove -y ${{ steps.verify.outputs.pkg }}" 2>&1 | tee remove.log
             # yum remove exits with code 0 even if scriptlets fail, so look for some sign of failure
             ! grep -qE '(err|warn|fail)' remove.log
             ;;

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1177,18 +1177,28 @@ jobs:
                   EXTRA_LINTIAN_ARGS="${EXTRA_LINTIAN_ARGS} --fail-on error,warning"
                   ;;
               esac
+            else
+              case ${OS_REL} in
+                focal|bionic|stretch|buster)
+                  ;;
+
+                *)
+                  EXTRA_LINTIAN_ARGS="${EXTRA_LINTIAN_ARGS} --fail-on error"
+                  ;;
+              esac
             fi
 
             lintian --version
             lintian --allow-root -v ${EXTRA_LINTIAN_ARGS} target/debian/*.deb
             ;;
+
           centos)
             # cargo generate-rpm creates RPMs that rpmlint considers to have errors so don't use the rpmlint exit code
             # otherwise we will always abort the workflow.
             if [[ "${{ inputs.strict_mode }}" == "true" ]]; then
               rpmlint target/generate-rpm/*.rpm
             else
-            rpmlint target/generate-rpm/*.rpm || true
+              rpmlint target/generate-rpm/*.rpm || true
             fi
             ;;
         esac

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -777,8 +777,8 @@ jobs:
                 ;;
 
               8)
-                yum install -y python3-pip python3-magic
-                pip3 install rpmlint
+                yum install -y cpio python3-pip
+                pip3 install python-magic rpmlint
                 ;;
             esac
             ;;

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1207,8 +1207,6 @@ jobs:
             # cargo generate-rpm creates RPMs that rpmlint considers to have errors so don't use the rpmlint exit code
             # otherwise we will always abort the workflow.
 
-            EXTRA_RPMLINT_ARGS=
-
             # The no-binary check is being raised for some reason, and other checks are failing relating to "tags" that
             # cargo-generate-rpm does not currently support setting. The only way to disable certain checks is by
             # writing a config file to disk. At the time of writing versions of rpmlint encountered were:
@@ -1224,10 +1222,14 @@ jobs:
             # See: https://github.com/rpm-software-management/rpmlint/blob/2.4.0/README.md#configuration
             # See: https://github.com/rpm-software-management/rpmlint/blob/rpmlint-1.4/README#L39
             # See: https://github.com/cat-in-136/cargo-generate-rpm/issues/20
+
+            EXTRA_RPMLINT_ARGS=
+            LINTER_CONFIG_PATH="$HOME/.config/rpmlint"
+
             case ${OS_REL} in
               7)
                 mkdir $HOME/.config
-                cat <<'EOF' >$HOME/.config/rpmlint
+                cat <<'EOF' >${LINTER_CONFIG_PATH}
         from Config import *
         addFilter("E: no-binary")
         addFilter("E: no-buildhost-tag")
@@ -1240,7 +1242,6 @@ jobs:
                   EXTRA_RPMLINT_ARGS="${EXTRA_RPMLINT_ARGS} --strict"
                 fi
 
-                LINTER_CONFIG_PATH="$HOME/.config/rpmlint"
                 mkdir $HOME/.config
                 cat <<'EOF' >${LINTER_CONFIG_PATH}
         addFilter("E: no-binary")
@@ -1251,10 +1252,6 @@ jobs:
         addFilter("E: no-signature")
         addFilter("E: no-url-tag")
         EOF
-
-                for CHECK_NAME in ${{ matrix.rpm_rpmlint_check_filters }}; do
-                  echo 'addFilter("E: '${CHECK_NAME}'")' >> ${LINTER_CONFIG_PATH}
-                done
 
                 # rpmlint 2.x requires that we explicitly tell it where the config file is, and the pip installed
                 # version doesn't come with any existing list of valid licenses so we have to install one ourselves.
@@ -1269,6 +1266,12 @@ jobs:
                 EXTRA_RPMLINT_ARGS="${EXTRA_RPMLINT_ARGS} --rpmlintrc ${LINTER_CONFIG_PATH} --config ${LICENSES_CONF_PATH}"
                 ;;
             esac
+
+            for CHECK_NAME in ${{ matrix.rpm_rpmlint_check_filters }}; do
+              echo 'addFilter("E: '${CHECK_NAME}'")' >> ${LINTER_CONFIG_PATH}
+            done
+
+            cat ${LINTER_CONFIG_PATH}
 
             rpmlint --version
             rpmlint ${EXTRA_RPMLINT_ARGS} target/generate-rpm/*.rpm

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -769,13 +769,15 @@ jobs:
             yum install epel-release -y
             yum install -y findutils gcc jq ${{ inputs.rpm_extra_build_packages }}
 
+            # note: we also install python magic otherwise binaries are not identified as such and rpmlint outputs:
+            #   E: no-binary
             case ${OS_REL} in
               7)
-                yum install -y rpmlint
+                yum install -y python-magic rpmlint
                 ;;
 
               8)
-                yum install -y python3-pip
+                yum install -y python3-pip python3-magic
                 pip3 install rpmlint
                 ;;
             esac

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1207,9 +1207,10 @@ jobs:
             # cargo generate-rpm creates RPMs that rpmlint considers to have errors so don't use the rpmlint exit code
             # otherwise we will always abort the workflow.
 
-            # The no-binary check is being raised for some reason, and other checks are failing relating to "tags" that
-            # cargo-generate-rpm does not currently support setting. The only way to disable certain checks is by
-            # writing a config file to disk. At the time of writing versions of rpmlint encountered were:
+            # rpmlint checks are failing that relate to "tags" that cargo-generate-rpm does not currently support
+            # setting. The only way to disable certain checks is by writing a config file to disk. At the time of
+            # writing versions of rpmlint encountered were:
+            #
             #    centos:7 Docker image    : rpmlint 1.5
             #    rockylinux:8 Docker image: rpmlint 1.10
             #    rockylinux:8 Docker image: rpmlint 2.4.0 (via pip3 install rpmlint)
@@ -1231,9 +1232,8 @@ jobs:
                 mkdir $HOME/.config
                 cat <<'EOF' >${LINTER_CONFIG_PATH}
         from Config import *
-        setBadness('no-binary', 0)
-        setBadness('no-buildhost-tag', 0)
-        setBadness('no-changelogname-tag', 0)
+        addFilter(".: no-buildhost-tag")
+        addFilter(".: no-changelogname-tag")
         EOF
                 ;;
 
@@ -1244,13 +1244,12 @@ jobs:
 
                 mkdir $HOME/.config
                 cat <<'EOF' >${LINTER_CONFIG_PATH}
-        setBadness('no-binary', 0)
-        setBadness('no-buildhost-tag', 0)
-        setBadness('no-changelogname-tag', 0)
-        setBadness('no-group-tag', 0)
-        setBadness('no-packager-tag', 0)
-        setBadness('no-signature', 0)
-        setBadness('no-url-tag', 0)
+        addFilter(".: no-buildhost-tag")
+        addFilter(".: no-changelogname-tag")
+        addFilter(".: no-group-tag")
+        addFilter(".: no-packager-tag")
+        addFilter(".: no-signature")
+        addFilter(".: no-url-tag")
         EOF
 
                 # rpmlint 2.x requires that we explicitly tell it where the config file is, and the pip installed
@@ -1268,7 +1267,7 @@ jobs:
             esac
 
             for CHECK_NAME in ${{ matrix.rpm_rpmlint_check_filters }}; do
-              echo "setBadness('${CHECK_NAME}', 0)" >> ${LINTER_CONFIG_PATH}
+              echo 'addFilter(".: '${CHECK_NAME}'")' >> ${LINTER_CONFIG_PATH}
             done
 
             cat ${LINTER_CONFIG_PATH}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1236,6 +1236,18 @@ jobs:
                 if [[ "${{ inputs.strict_mode }}" == "true" ]]; then
                   EXTRA_RPMLINT_ARGS="${EXTRA_RPMLINT_ARGS} --strict"
                 fi
+
+                mkdir ~/.config
+                cat <<'EOF' >~/.config/rpmlint
+        addFilter("E: no-binary")
+        addFilter("E: no-buildhost-tag")
+        addFilter("E: no-changelogname-tag")
+        addFilter("E: no-signature")
+        addFilter("E: no-packager-tag")
+        addFilter("E: no-group-tag")
+        EOF
+
+                EXTRA_RPMLINT_ARGS="${EXTRA_RPMLINT_ARGS} --rpmlintrc ~/.config/rpmlint"
                 ;;
             esac
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1231,11 +1231,17 @@ jobs:
 
             case ${OS_REL} in
               7)
+                # On CentOS 7 we only have the older rpmlint 1.x available, which has a known issue with the
+                # `missing-call-to-chdir-with-chroot` check causing false positives, therefore we filter this error
+                # out. The false positive issue was fixed in rpmlint 2.x.
+                #
+                # See: https://github.com/rpm-software-management/rpmlint/issues/84
                 mkdir $HOME/.config
                 cat <<'EOF' >${LINTER_CONFIG_PATH}
         from Config import *
         addFilter(".: no-buildhost-tag")
         addFilter(".: no-changelogname-tag")
+        addFilter(".: missing-call-to-chdir-with-chroot")
         EOF
                 ;;
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1207,7 +1207,7 @@ jobs:
             # cargo generate-rpm creates RPMs that rpmlint considers to have errors so don't use the rpmlint exit code
             # otherwise we will always abort the workflow.
 
-            EXTRA_RPMLINT_ARGS="${{ matrix.rpm_extra_rpmlint_args }}"
+            EXTRA_RPMLINT_ARGS=
 
             # The no-binary check is being raised for some reason, and other checks are failing relating to "tags" that
             # cargo-generate-rpm does not currently support setting. The only way to disable certain checks is by
@@ -1246,10 +1246,15 @@ jobs:
         addFilter("E: no-binary")
         addFilter("E: no-buildhost-tag")
         addFilter("E: no-changelogname-tag")
-        addFilter("E: no-signature")
-        addFilter("E: no-packager-tag")
         addFilter("E: no-group-tag")
+        addFilter("E: no-packager-tag")
+        addFilter("E: no-signature")
+        addFilter("E: no-url-tag")
         EOF
+
+                for CHECK_NAME in ${{ matrix.rpm_rpmlint_check_filters }}; do
+                  echo 'addFilter("E: '${CHECK_NAME}'")' >> ${LINTER_CONFIG_PATH}
+                done
 
                 # rpmlint 2.x requires that we explicitly tell it where the config file is, and the pip installed
                 # version doesn't come with any existing list of valid licenses so we have to install one ourselves.

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1251,6 +1251,7 @@ jobs:
         addFilter(".: no-packager-tag")
         addFilter(".: no-signature")
         addFilter(".: no-url-tag")
+        addFilter(".: unused-rpmlintrc-filter")
         EOF
 
                 # rpmlint 2.x requires that we explicitly tell it where the config file is, and the pip installed

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -311,14 +311,19 @@ jobs:
           EOF
           )
           if [[ -f "${DOCKER_BUILD_RULES}" ]]; then
-            JSON=$(yq "${DOCKER_BUILD_RULES}" -I=0 -p=yaml -o=json)
+            DOCKER_BUILD_RULES_RAW_JSON=$(yq "${DOCKER_BUILD_RULES}" -I=0 -p=yaml -o=json)
           else
-            JSON=$(echo "${DOCKER_BUILD_RULES}" | yq -I=0 -p=yaml -o=json)
+            DOCKER_BUILD_RULES_RAW_JSON=$(echo "${DOCKER_BUILD_RULES}" | yq -I=0 -p=yaml -o=json)
           fi
-          JSON=$(echo $JSON | jq '(.. | select(has("crosstarget")?)) |= with_entries(if .key == "crosstarget" then .key = "target" else . end)')
+
+          # Convert string values to array of single string values (as GitHub matrix values must be arrays)
+          DOCKER_BUILD_RULES_PROCESSED_JSON=$(echo ${DOCKER_BUILD_RULES_RAW_JSON} | jq 'with_entries(if .value | type == "string" then .value |= [.] elif .value | type != "array" then error("rule values must be strings or arrays") else . end)')
+
+          # Rename "crosstarget" keys to "target" (we support "crosstarget" for backward compatibility)
+          DOCKER_BUILD_RULES_PROCESSED_JSON=$(echo ${DOCKER_BUILD_RULES_PROCESSED_JSON} | jq '(.. | select(has("crosstarget")?)) |= with_entries(if .key == "crosstarget" then .key = "target" else . end)')
 
           echo "docker_build_rules<<END_OF_DOCKER_BUILD_RULES" >> $GITHUB_OUTPUT
-          echo ${JSON} | jq >> $GITHUB_OUTPUT
+          echo ${DOCKER_BUILD_RULES_PROCESSED_JSON} | jq >> $GITHUB_OUTPUT
           echo 'END_OF_DOCKER_BUILD_RULES' >> $GITHUB_OUTPUT
 
           PACKAGE_BUILD_RULES=$(cat <<'EOF'
@@ -331,12 +336,15 @@ jobs:
             PACKAGE_BUILD_RULES_RAW_JSON=$(echo "${PACKAGE_BUILD_RULES}" | yq -I=0 -p=yaml -o=json)
           fi
 
+          # Convert string values to array of single string values (as GitHub matrix values must be arrays)
+          PACKAGE_BUILD_RULES_PROCESSED_JSON=$(echo ${PACKAGE_BUILD_RULES_RAW_JSON} | jq 'with_entries(if .value | type == "string" then .value |= [.] elif .value | type != "array" then error("rule values must be strings or arrays") else . end)')
+
           # Don't permute the build job over variables intended only for use by the pkg-test job but which were supplied
           # via package_build_rules as a convenience for the user to avoid having to supply package_test_rules which
           # would be mostly identical to package_build_rules. If we don't remove this we end up causing duplicate Build
           # jobs to be spawned for each different test mode (fresh-install vs upgrade-from-published) which for the
           # pkb job are identical and thus pointless waste and just plain confusing.
-          PACKAGE_BUILD_RULES_PROCESSED_JSON=$(echo ${PACKAGE_BUILD_RULES_RAW_JSON} | jq -c 'del(.mode) | del(.include[]?.mode)')
+          PACKAGE_BUILD_RULES_PROCESSED_JSON=$(echo ${PACKAGE_BUILD_RULES_PROCESSED_JSON} | jq -c 'del(.mode) | del(.include[]?.mode)')
 
           echo "package_build_rules<<END_OF_PACKAGE_BUILD_RULES" >> $GITHUB_OUTPUT
           echo ${PACKAGE_BUILD_RULES_PROCESSED_JSON} | jq >> $GITHUB_OUTPUT
@@ -356,8 +364,10 @@ jobs:
             PACKAGE_TEST_RULES_RAW_JSON=$(echo "${PACKAGE_TEST_RULES}" | yq -I=0 -p=yaml -o=json)
           fi
 
+          # Convert string values to array of single string values (as GitHub matrix values must be arrays)
+          PACKAGE_TEST_RULES_PROCESSED_JSON=$(echo ${PACKAGE_TEST_RULES_RAW_JSON} | jq 'with_entries(if .value | type == "string" then .value |= [.] elif .value | type != "array" then error("rule values must be strings or arrays") else . end)')
+
           # Exclude debian:stretch because the LXC image is no longer available
-          PACKAGE_TEST_RULES_PROCESSED_JSON="${PACKAGE_TEST_RULES_RAW_JSON}"
           if [[ "${PACKAGE_TEST_RULES_RAW_JSON}" != "{}" ]]; then
             CONTROL_JSON=$(echo ${PACKAGE_TEST_RULES_RAW_JSON} | jq -c)
             MODIFIED_JSON=$(echo ${PACKAGE_TEST_RULES_RAW_JSON} | jq -c 'del(.image[]? | select(. == "debian:stretch")) | del(.include[]? | select(.image == "debian:stretch"))')

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1231,9 +1231,9 @@ jobs:
                 mkdir $HOME/.config
                 cat <<'EOF' >${LINTER_CONFIG_PATH}
         from Config import *
-        setBadness('no-binary'. 0)
-        setBadness('no-buildhost-tag'. 0)
-        setBadness('no-changelogname-tag'. 0)
+        setBadness('no-binary', 0)
+        setBadness('no-buildhost-tag', 0)
+        setBadness('no-changelogname-tag', 0)
         EOF
                 ;;
 
@@ -1244,13 +1244,13 @@ jobs:
 
                 mkdir $HOME/.config
                 cat <<'EOF' >${LINTER_CONFIG_PATH}
-        setBadness('no-binary'. 0)
-        setBadness('no-buildhost-tag'. 0)
-        setBadness('no-changelogname-tag'. 0)
-        setBadness('no-group-tag'. 0)
-        setBadness('no-packager-tag'. 0)
-        setBadness('no-signature'. 0)
-        setBadness('no-url-tag'. 0)
+        setBadness('no-binary', 0)
+        setBadness('no-buildhost-tag', 0)
+        setBadness('no-changelogname-tag', 0)
+        setBadness('no-group-tag', 0)
+        setBadness('no-packager-tag', 0)
+        setBadness('no-signature', 0)
+        setBadness('no-url-tag', 0)
         EOF
 
                 # rpmlint 2.x requires that we explicitly tell it where the config file is, and the pip installed
@@ -1268,7 +1268,7 @@ jobs:
             esac
 
             for CHECK_NAME in ${{ matrix.rpm_rpmlint_check_filters }}; do
-              echo 'setBadness(''${CHECK_NAME}''. 0)' >> ${LINTER_CONFIG_PATH}
+              echo 'setBadness(''${CHECK_NAME}'', 0)' >> ${LINTER_CONFIG_PATH}
             done
 
             cat ${LINTER_CONFIG_PATH}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1196,19 +1196,18 @@ jobs:
             # cargo generate-rpm creates RPMs that rpmlint considers to have errors so don't use the rpmlint exit code
             # otherwise we will always abort the workflow.
 
-            if [[ "${OS_NAME}:${OS_REL}" == "centos:7" ]]; then
-              # The no-binary check is faulty on older rpmlint versions and the only way to disable the check is by
-              # writing a config file to disk. Also filter out the no-buildhost-tag and no-changelogname-tag errors
-              # as we have no way to set them.
-              # See: hhttps://github.com/rpm-software-management/rpmlint/blob/rpmlint-1.4/README#L39
-              mkdir ~/.config
-              cat <<'EOF' >~/.config/rpmlint
+            # The no-binary check is faulty on older rpmlint versions and the only way to disable the check is by
+            # writing a config file to disk. Also filter out the no-buildhost-tag and no-changelogname-tag errors as we
+            # have no way to add the missing tags.
+            # See: https://github.com/rpm-software-management/rpmlint/blob/rpmlint-1.4/README#L39
+            # See: https://github.com/cat-in-136/cargo-generate-rpm/issues/20
+            mkdir ~/.config
+            cat <<'EOF' >~/.config/rpmlint
         from Config import *
         addFilter("E: no-binary")
         addFilter("E: no-buildhost-tag")
         addFilter("E: no-changelogname-tag")
         EOF
-            fi
 
             if [[ "${{ inputs.strict_mode }}" == "true" ]]; then
               rpmlint target/generate-rpm/*.rpm

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -767,7 +767,18 @@ jobs:
           centos)
             #sed -i -e 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf || true
             yum install epel-release -y
-            yum install -y findutils gcc jq rpmlint ${{ inputs.rpm_extra_build_packages }}
+            yum install -y findutils gcc jq ${{ inputs.rpm_extra_build_packages }}
+
+            case ${OS_REL} in
+              7)
+                yum install -y rpmlint
+                ;;
+
+              8)
+                yum install -y python3-pip
+                pip3 install rpmlint
+                ;;
+            esac
             ;;
         esac
 
@@ -1196,24 +1207,31 @@ jobs:
             # cargo generate-rpm creates RPMs that rpmlint considers to have errors so don't use the rpmlint exit code
             # otherwise we will always abort the workflow.
 
-            # The no-binary check is faulty on older rpmlint versions and the only way to disable the check is by
-            # writing a config file to disk. Also filter out the no-buildhost-tag and no-changelogname-tag errors as we
-            # have no way to add the missing tags.
-            # See: https://github.com/rpm-software-management/rpmlint/blob/rpmlint-1.4/README#L39
-            # See: https://github.com/cat-in-136/cargo-generate-rpm/issues/20
-            mkdir ~/.config
-            cat <<'EOF' >~/.config/rpmlint
+            if [[ "${OS_REL}" == "7" ]]; then
+              # The no-binary check is faulty on older rpmlint versions and the only way to disable the check is by 
+              # writing a config file to disk. Also filter out the no-buildhost-tag and no-changelogname-tag errors as
+              # we have no way to add the missing tags. At the time of writing versions encountered were:
+              #    centos:7 Docker image    : rpmlint 1.5
+              #    rockylinux:8 Docker image: rpmlint 1.10
+              # Both wrongly raise "E: no-binary"
+              #
+              # CentOS / RockyLinux 8 supports rpmlint 2.x via python3-pip, so we can use the newer version instead,
+              # but this can't be installed on CentOS 7 due to a missing rpm-python3 RPM bindings package needed by pip3
+              # install.
+              #
+              # See: https://github.com/rpm-software-management/rpmlint/blob/rpmlint-1.4/README#L39
+              # See: https://github.com/cat-in-136/cargo-generate-rpm/issues/20
+              mkdir ~/.config
+              cat <<'EOF' >~/.config/rpmlint
         from Config import *
         addFilter("E: no-binary")
         addFilter("E: no-buildhost-tag")
         addFilter("E: no-changelogname-tag")
         EOF
-
-            if [[ "${{ inputs.strict_mode }}" == "true" ]]; then
-              rpmlint target/generate-rpm/*.rpm
-            else
-              rpmlint target/generate-rpm/*.rpm || true
             fi
+
+            rpmlint --version
+            rpmlint target/generate-rpm/*.rpm
             ;;
         esac
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1195,6 +1195,21 @@ jobs:
           centos)
             # cargo generate-rpm creates RPMs that rpmlint considers to have errors so don't use the rpmlint exit code
             # otherwise we will always abort the workflow.
+
+            if [[ "${OS_NAME}:${OS_REL}" == "centos:7" ]]; then
+              # The no-binary check is faulty on older rpmlint versions and the only way to disable the check is by
+              # writing a config file to disk. Also filter out the no-buildhost-tag and no-changelogname-tag errors
+              # as we have no way to set them.
+              # See: hhttps://github.com/rpm-software-management/rpmlint/blob/rpmlint-1.4/README#L39
+              mkdir ~/.config
+              cat <<'EOF' >~/.config/rpmlint
+        from Config import *
+        addFilter("E: no-binary")
+        addFilter("E: no-buildhost-tag")
+        addFilter("E: no-changelogname-tag")
+        EOF
+            fi
+
             if [[ "${{ inputs.strict_mode }}" == "true" ]]; then
               rpmlint target/generate-rpm/*.rpm
             else

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1208,21 +1208,23 @@ jobs:
             # otherwise we will always abort the workflow.
 
             EXTRA_RPMLINT_ARGS="${{ matrix.rpm_extra_rpmlint_args }}"
+
+            # The no-binary check is being raised for some reason, and other checks are failing relating to "tags" that
+            # cargo-generate-rpm does not currently support setting. The only way to disable certain checks is by
+            # writing a config file to disk. At the time of writing versions of rpmlint encountered were:
+            #    centos:7 Docker image    : rpmlint 1.5
+            #    rockylinux:8 Docker image: rpmlint 1.10
+            #    rockylinux:8 Docker image: rpmlint 2.4.0 (via pip3 install rpmlint)
+            #
+            # CentOS / RockyLinux 8 supports rpmlint 2.x via python3-pip, so we can use the newer version instead, but
+            # this can't be installed on CentOS 7 due to a missing rpm-python3 RPM bindings package needed by pip3
+            # install.
+            #
+            # See: https://github.com/rpm-software-management/rpmlint/blob/2.4.0/README.md#configuration
+            # See: https://github.com/rpm-software-management/rpmlint/blob/rpmlint-1.4/README#L39
+            # See: https://github.com/cat-in-136/cargo-generate-rpm/issues/20
             case ${OS_REL} in
               7)
-                # The no-binary check is faulty on older rpmlint versions and the only way to disable the check is by 
-                # writing a config file to disk. Also filter out the no-buildhost-tag and no-changelogname-tag errors as
-                # we have no way to add the missing tags. At the time of writing versions encountered were:
-                #    centos:7 Docker image    : rpmlint 1.5
-                #    rockylinux:8 Docker image: rpmlint 1.10
-                # Both wrongly raise "E: no-binary"
-                #
-                # CentOS / RockyLinux 8 supports rpmlint 2.x via python3-pip, so we can use the newer version instead,
-                # but this can't be installed on CentOS 7 due to a missing rpm-python3 RPM bindings package needed by pip3
-                # install.
-                #
-                # See: https://github.com/rpm-software-management/rpmlint/blob/rpmlint-1.4/README#L39
-                # See: https://github.com/cat-in-136/cargo-generate-rpm/issues/20
                 mkdir ~/.config
                 cat <<'EOF' >~/.config/rpmlint
         from Config import *

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1231,9 +1231,9 @@ jobs:
                 mkdir $HOME/.config
                 cat <<'EOF' >${LINTER_CONFIG_PATH}
         from Config import *
-        addFilter(".: no-binary")
-        addFilter(".: no-buildhost-tag")
-        addFilter(".: no-changelogname-tag")
+        setBadness('no-binary'. 0)
+        setBadness('no-buildhost-tag'. 0)
+        setBadness('no-changelogname-tag'. 0)
         EOF
                 ;;
 
@@ -1244,14 +1244,13 @@ jobs:
 
                 mkdir $HOME/.config
                 cat <<'EOF' >${LINTER_CONFIG_PATH}
-        addFilter(".: no-binary")
-        addFilter(".: no-buildhost-tag")
-        addFilter(".: no-changelogname-tag")
-        addFilter(".: no-group-tag")
-        addFilter(".: no-packager-tag")
-        addFilter(".: no-signature")
-        addFilter(".: no-url-tag")
-        addFilter(".: unused-rpmlintrc-filter")
+        setBadness('no-binary'. 0)
+        setBadness('no-buildhost-tag'. 0)
+        setBadness('no-changelogname-tag'. 0)
+        setBadness('no-group-tag'. 0)
+        setBadness('no-packager-tag'. 0)
+        setBadness('no-signature'. 0)
+        setBadness('no-url-tag'. 0)
         EOF
 
                 # rpmlint 2.x requires that we explicitly tell it where the config file is, and the pip installed
@@ -1269,7 +1268,7 @@ jobs:
             esac
 
             for CHECK_NAME in ${{ matrix.rpm_rpmlint_check_filters }}; do
-              echo 'addFilter(".: '${CHECK_NAME}'")' >> ${LINTER_CONFIG_PATH}
+              echo 'setBadness(''${CHECK_NAME}''. 0)' >> ${LINTER_CONFIG_PATH}
             done
 
             cat ${LINTER_CONFIG_PATH}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1268,7 +1268,7 @@ jobs:
             esac
 
             for CHECK_NAME in ${{ matrix.rpm_rpmlint_check_filters }}; do
-              echo 'setBadness(''${CHECK_NAME}'', 0)' >> ${LINTER_CONFIG_PATH}
+              echo 'setBadness('${CHECK_NAME}', 0)' >> ${LINTER_CONFIG_PATH}
             done
 
             cat ${LINTER_CONFIG_PATH}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1180,7 +1180,7 @@ jobs:
                 focal)
                   ;;
 
-                bionic|stretch|buster)
+                xenial|bionic|stretch|buster)
                   EXTRA_LINTIAN_ARGS="${EXTRA_LINTIAN_ARGS} --fail-on-warnings"
                   ;;
 
@@ -1190,7 +1190,7 @@ jobs:
               esac
             else
               case ${OS_REL} in
-                focal|bionic|stretch|buster)
+                focal|xenial|bionic|stretch|buster)
                   ;;
 
                 *)

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -284,7 +284,7 @@ jobs:
   prepare:
     runs-on: ubuntu-22.04
     outputs:
-      cargo_name: ${{ steps.verify.outputs.cargo_name }}
+      cargo_name: ${{ steps.verify_inputs.outputs.cargo_name }}
       has_docker_secrets: ${{ steps.verify_inputs.outputs.has_docker_secrets }}
       all_repo_and_tag_pairs: ${{ steps.encode.outputs.all_repo_and_tag_pairs }}
       first_repo_and_tag_pair: ${{ steps.encode.outputs.first_repo_and_tag_pair }}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1231,9 +1231,9 @@ jobs:
                 mkdir $HOME/.config
                 cat <<'EOF' >${LINTER_CONFIG_PATH}
         from Config import *
-        addFilter("E: no-binary")
-        addFilter("E: no-buildhost-tag")
-        addFilter("E: no-changelogname-tag")
+        addFilter(".: no-binary")
+        addFilter(".: no-buildhost-tag")
+        addFilter(".: no-changelogname-tag")
         EOF
                 ;;
 
@@ -1244,13 +1244,13 @@ jobs:
 
                 mkdir $HOME/.config
                 cat <<'EOF' >${LINTER_CONFIG_PATH}
-        addFilter("E: no-binary")
-        addFilter("E: no-buildhost-tag")
-        addFilter("E: no-changelogname-tag")
-        addFilter("E: no-group-tag")
-        addFilter("E: no-packager-tag")
-        addFilter("E: no-signature")
-        addFilter("E: no-url-tag")
+        addFilter(".: no-binary")
+        addFilter(".: no-buildhost-tag")
+        addFilter(".: no-changelogname-tag")
+        addFilter(".: no-group-tag")
+        addFilter(".: no-packager-tag")
+        addFilter(".: no-signature")
+        addFilter(".: no-url-tag")
         EOF
 
                 # rpmlint 2.x requires that we explicitly tell it where the config file is, and the pip installed
@@ -1268,7 +1268,7 @@ jobs:
             esac
 
             for CHECK_NAME in ${{ matrix.rpm_rpmlint_check_filters }}; do
-              echo 'addFilter("E: '${CHECK_NAME}'")' >> ${LINTER_CONFIG_PATH}
+              echo 'addFilter(".: '${CHECK_NAME}'")' >> ${LINTER_CONFIG_PATH}
             done
 
             cat ${LINTER_CONFIG_PATH}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1185,7 +1185,11 @@ jobs:
           centos)
             # cargo generate-rpm creates RPMs that rpmlint considers to have errors so don't use the rpmlint exit code
             # otherwise we will always abort the workflow.
+            if [[ "${{ inputs.strict_mode }}" == "true" ]]; then
+              rpmlint target/generate-rpm/*.rpm
+            else
             rpmlint target/generate-rpm/*.rpm || true
+            fi
             ;;
         esac
 

--- a/docs/minimal_useful_example.md
+++ b/docs/minimal_useful_example.md
@@ -54,8 +54,8 @@ jobs:
       docker_org: my_org
       docker_repo: my_image_name
       docker_build_rules: |
-        platform: ["linux/amd64"]
-        shortname: ["amd64"]
+        platform: "linux/amd64"
+        shortname: "amd64"
 ```
 
 There are a few things to note here:

--- a/docs/os_packaging.md
+++ b/docs/os_packaging.md
@@ -75,9 +75,9 @@ jobs:
     uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v5
     with:
       package_build_rules: |
-        pkg: ["mytest"]
-        image: ["ubuntu:jammy"]
-        target: ["x86_64"]
+        pkg: mytest
+        image: "ubuntu:jammy"
+        target: x86_64
 ```
 
 Assuming that you have just created an empty GitHub repository, let's setup Git to push to it, add & commit the files we have created and push them to GitHub:

--- a/docs/os_packaging.md
+++ b/docs/os_packaging.md
@@ -165,7 +165,6 @@ Both `cargo-deb` and `cargo-generate-rpm` have a `variant` feature. Ploutos will
 | `deb_extra_build_packages` | string | No | A space separated set of additional Debian packages to install in the build host when (not cross) compiling. |
 | `deb_apt_key_url` | string | No* | The URL of the public key that can be used to verify a signed package if installing using `deb_apt_source`. Defaults to the NLnet Labs package repository key URL. |
 | `deb_apt_source` | string | No* | A line or lines to write to an APT `/etc/apt/sources.list.d/` file, or the relative path to such a file to install. Used when `mode` of `package_test_rules` is `upgrade-from-published`. Defaults to the NLnet Labs package installation settings. |
-| `deb_extra_lintian_args` | string | No | A space separated set of additional command line arguments to pass to the Debian Lintian package linting tool. Useful to suppress errors you wish to ignore or to supress warnings when `strict_mode` is set to `true`. |
 | `rpm_extra_build_packages` | string | No | A space separated set of additional RPM packages to install in the build host when (not cross) compiling. |
 | `rpm_scriptlets_path` | string | No | The path to a TOML file defining one or more of the `pre_install_script`, `pre_uninstall_script`, `post_install_script` and/or `post_uninstall_script` `cargo-generate-rpm` settings. |
 | `rpm_yum_key_url` | string | No* | The URL of the public key that can be used to verify a signed package if installing using `rpm_yum_repo`. Defaults to the NLnet Labs package repository key URL. |
@@ -191,7 +190,9 @@ A rules [matrix](./key_concepts_and_config.md#matrix-rules) with the following k
 | `target` | Yes | Should be `x86_64` If `x86_64` the Rust application will be compiled using `cargo-deb` (for DEB) or `cargo build` (for RPM) and stripped. Otherwise it will be used to determine the cross-compiled binary GitHub Actions artifact to compile and download. |
 | `os` | No | Overrides the value of `image` when determining `os_name` and `os_rel`. |
 | `extra_build_args` | No | A space separated set of additional command line arguments to pass to `cargo-deb`/`cargo build`. |
+| `deb_extra_lintian_args` | No | A space separated set of additional command line arguments to pass to the Debian Lintian package linting tool. Useful to suppress errors you wish to ignore or to supress warnings when `strict_mode` is set to `true`. |
 | `rpm_systemd_service_unit_file` | No | Relative path to the systemd file, or files (if it ends with `*`) to inclde in an RPM package. See below for more info. |
+| `rpm_rpmlint_check_filters` | No | A space separated set of additional rpmlint checks to filter out. See https://fedoraproject.org/wiki/Common_Rpmlint_issues for some example check names, e.g. `no-documentation`. |
 
 **Note:** When `package_test_rules` is not supplied the `package_build_rules` matrix is also used as the `package_test_rules` matrix, since normally you want to test every package that you build. When using `package_build_rules` this way you can also supply `package_test_rules` matrix keys in the `package_build_rules` input. These will be ignored by the package building workflow job.
 


### PR DESCRIPTION
This release contains the following changes:

- Permit `key: value` in rules instead of requiring `key: [value]` for a single element array.
- Don't require a `pkg` name when building a single O/S package (the majority case).
- Correctly enable failing on DEB lint errors on newer O/S's (e.g. Jammy), as already happens on older O/S's.
- Enable `rpmlint --strict` when `strict_mode` is `true` and `rpmlint` version >= 2 (i.e. still not for the oldest O/S's).
- Added new build rule key `rpm_rpmlint_check_filters` to enable certain `rpmlint` failures to be ignored.
- Prevent `rpmlint` error `E: no-binary` by installing the required `python-magic` dependency in the build container.
- Suppress `rpmlint` warnings for tags that are not yet supported by `cargo-generate-rpm`. The full list of suppresed warnings is:
  - `no-buildhost-tag`
  - `no-changelogname-tag`
  - `no-group-tag`
  - `no-packager-tag`
  - `no-signature`
  - `no-url-tag`
- Suppress `rpmlint` error `missing-call-to-chdir-with-chroot` as it only appears to exist on older `rpmlint` versions and was reported as potentially causing [false positives](https://github.com/rpm-software-management/rpmlint/issues/84)

Successful test runs can be seen here:
- dev branch: https://github.com/NLnetLabs/ploutos-testing/actions/runs/3539403642
- main branch: https://github.com/NLnetLabs/ploutos-testing/actions/runs/3540647923
- release tag: https://github.com/NLnetLabs/ploutos-testing/actions/runs/3540893594

Release checklist:
- [x] 1. Create a branch in the RELEASE repo, let's call this the RELEASE branch.
- [x] 2. Change RPM_MACROS_URL in the workflow to point to the new RELEASE branch.
- [x] 3. Create a PR in the RELEASE repo for the RELEASE branch.
- [x] 4. Create a matching branch in the TEST repo, let's call this the TEST branch.
- [x] 5. Make the desired changes to the RELEASE branch.
- [x] 6. In the TEST branch modify `.github/workflows/pkg.yml` so that instead of referring to `pkg-rust.yml@vX` it refers to `pkg-rust.yml@<Git ref of HEAD commit on the TEST branch>` or `pkg-rust.yml@<test branch name>`.
- [x] 7. Create a PR in the `.gihub-testing` repository from the TEST branch to `main`, let's call this the TEST PR.
- [x] 8. Repeat steps 4 and 5 until the the `Packaging` workflow run in the TEST PR passes and behaves as desired.
- [x] 9. Merge the TEST PR to the `main` branch.
- [x] 10. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo against the `main` branch passes and behaves as desired. If not, repeat steps 4-9 until the new TEST PR passes and behaves as desired.
- [x] 11. Create a release tag in the TEST repo with the same release tag as will be used in the RELEASE repo, e.g. v1.2.3. _**Note:** Remember to respect semantic versioning, i.e. if the changes being made are not backward compatible you will need to bump the MAJOR version (in MAJOR.MINOR.PATCH) **and** any workflows that invoke the reusable workflow will need to be **manually edited** to refer to the new MAJOR version._
- [x] 12. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo passes against the newly created release tag passes and behaves as desired. If not, delete the release tag **in the TEST repo** and repeat steps 4-11 until the new TEST PR passes and behaves as desired.
- [x] 13. Merge the RELEASE PR to the `main` branch.
- [ ] 14. Change RPM_MACROS_URL in the workflow to point to vX.Y.Z tag (that you are about to create).
- [ ] 15. Create the new release vX.Y.Z tag in the RELEASE repo.
- [ ] 16. Update the vX tag in the RELEASE repo to point to the new vX.Y.Z tag.
- [ ] 17. Edit `.github/workflows/pkg.yml` in the `main` branch of the TEST repo to refer again to `@vX`.
- [ ] 18. Verify that the `Packaging` action in the TEST repo against the `main` branch passes and works as desired.
- [ ] 19. (optional) If the MAJOR version was changed, update affected repositories that use the reusable workflow to use the new MAJOR version, including adjusting to any breaking changes introduced by the MAJOR version change.