### PR TITLE
Managed changelog test

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -978,44 +978,52 @@ jobs:
               fi
             fi
 
-            #
-            # Generate the changelog file that Debian packages are required to have.
-            # See: https://www.debian.org/doc/manuals/maint-guide/dreq.en.html#changelog
-            #
+            CHANGELOG_KEY="package.metadata.deb.changelog"
+            GEN_CHANGELOG_PATH="target/debian/changelog"
+            SET_CHANGELOG_PATH=$(toml get Cargo.toml ${CHANGELOG_KEY})
 
-            # 1. Use the same logic as cargo-deb, i.e. take the maintainer from the package.metadata.deb.maintainer
-            #    key in Cargo.toml (for the selected variant) if defined, else use the first author instead.
-            #
-            # Note:
-            #    With jq 1.6: del(..|nulls)
-            #    With jq 1.5: del(recurse(.[]?;true)|select(. == null))
-            #    Older systems only have jq 1.5 so we have to use the more verbose construct.
-            V=${VARIANT:-null}
-            MAINTAINER=$(cargo read-manifest | jq -r '[.metadata.deb.variants."'$V'".maintainer, .metadata.deb.maintainer, .authors[0]] | del(recurse(.[]?;true)|select(. == null))[0]')
+            case "${SET_CHANGELOG_PATH}" in
+              null|${GEN_CHANGELOG_PATH})
+                #
+                # Generate the changelog file that Debian packages are required to have.
+                # See: https://www.debian.org/doc/manuals/maint-guide/dreq.en.html#changelog
+                #
 
-            # 2. Generate the RFC 5322 format date by hand instead of using date --rfc-email because that option doesn't
-            #    exist on Ubuntu 16.04 and Debian 9
-            RFC5322_TS=$(LC_TIME=en_US.UTF-8 date +'%a, %d %b %Y %H:%M:%S %z')
+                # 1. Use the same logic as cargo-deb, i.e. take the maintainer from the package.metadata.deb.maintainer
+                #    key in Cargo.toml (for the selected variant) if defined, else use the first author instead.
+                #
+                # Note:
+                #    With jq 1.6: del(..|nulls)
+                #    With jq 1.5: del(recurse(.[]?;true)|select(. == null))
+                #    Older systems only have jq 1.5 so we have to use the more verbose construct.
+                V=${VARIANT:-null}
+                MAINTAINER=$(cargo read-manifest | jq -r '[.metadata.deb.variants."'$V'".maintainer, .metadata.deb.maintainer, .authors[0]] | del(recurse(.[]?;true)|select(. == null))[0]')
 
-            # 3. Generate the changelog file that Debian packages are required to have.
-            if [ ! -d target/debian ]; then
-              mkdir -p target/debian
-            fi
-            echo "${MATRIX_PKG} (${PKG_APP_VER}) unstable; urgency=medium" >target/debian/changelog
-            echo "  * See: https://github.com/${{ github.repository }}/releases/tag/v${APP_NEW_VER}" >>target/debian/changelog
-            echo " -- maintainer ${MAINTAINER}  ${RFC5322_TS}" >>target/debian/changelog
+                # 2. Generate the RFC 5322 format date by hand instead of using date --rfc-email because that option doesn't
+                #    exist on Ubuntu 16.04 and Debian 9
+                RFC5322_TS=$(LC_TIME=en_US.UTF-8 date +'%a, %d %b %Y %H:%M:%S %z')
 
-            # 4. Print the generated changelog for diagnostic purposes
-            echo "Generated changelog:"
-            cat target/debian/changelog
+                # 3. Generate the changelog file that Debian packages are required to have.
+                if [ ! -d target/debian ]; then
+                  mkdir -p target/debian
+                fi
+                echo "${MATRIX_PKG} (${PKG_APP_VER}) unstable; urgency=medium" >target/debian/changelog
+                echo "  * See: https://github.com/${{ github.repository }}/releases/tag/v${APP_NEW_VER}" >>target/debian/changelog
+                echo " -- maintainer ${MAINTAINER}  ${RFC5322_TS}" >>target/debian/changelog
 
-            # 5. Configure cargo-deb to use the generated changelog file
-            mv Cargo.toml Cargo.toml.org
-            toml set Cargo.toml.org package.metadata.deb.changelog target/debian/changelog > Cargo.toml
-            
-            #
-            # End changelog generation
-            #
+                # 4. Print the generated changelog for diagnostic purposes
+                echo "Generated changelog:"
+                cat target/debian/changelog
+
+                # 5. Configure cargo-deb to use the generated changelog file
+                mv Cargo.toml Cargo.toml.org
+                toml set Cargo.toml.org package.metadata.deb.changelog target/debian/changelog > Cargo.toml
+              
+                #
+                # End changelog generation
+                #
+                ;;
+            esac
 
             DEB_VER="${PKG_APP_VER}-1${OS_REL}"
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -661,6 +661,7 @@ jobs:
     env:
       CARGO_DEB_VER: 1.38.4
       CARGO_GENERATE_RPM_VER: 0.8.0
+      TOML_CLI_VER: 0.2.0
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
@@ -810,6 +811,13 @@ jobs:
         path: ~/.cargo/bin/cargo-generate-rpm
         key: ${{ matrix.image }}-cargo-generate-rpm-${{ env.CARGO_GENERATE_RPM_VER }}
 
+    - name: Cache TOML-CLI if available
+      id: cache-toml-cli
+      uses: actions/cache@v3
+      with:
+        path: ~/.cargo/bin/toml
+        key: ${{ matrix.image }}-toml-cli-${{ env.TOML_CLI_VER }}
+
     # Only install cargo-deb or cargo-generate-rpm if not already fetched from the cache.
     - name: Install Cargo Deb if needed
       if: ${{ steps.cache-cargo-deb.outputs.cache-hit != 'true' }}
@@ -838,6 +846,11 @@ jobs:
             cargo install cargo-generate-rpm --version ${CARGO_GENERATE_RPM_VER} --locked
             ;;
         esac
+
+    - name: Install TOML-CLI if needed
+      if: ${{ steps.cache-toml-cli.outputs.cache-hit != 'true' }}
+      run: |
+        cargo install toml-cli --version ${TOML_CLI_VER} --locked
 
     - name: Download cross-compiled binaries
       if: ${{ matrix.target != 'x86_64' }}
@@ -980,11 +993,9 @@ jobs:
             echo "Generated changelog:"
             cat target/debian/changelog
 
-            #sed -i -e "s/\[package.metadata.deb\]/[package.metadata.deb]\nchangelog = \"target\/debian\/changelog\"/" Cargo.toml
-            cargo install toml-cli
+            # 5. Configure cargo-deb to use the generated changelog file
             mv Cargo.toml Cargo.toml.org
             toml set Cargo.toml.org package.metadata.deb.changelog target/debian/changelog > Cargo.toml
-            cat Cargo.toml
             
             #
             # End changelog generation

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -765,12 +765,12 @@ jobs:
       run: |
         case ${OS_NAME} in
           debian|ubuntu)
-            apt-get install -y binutils gcc dpkg-dev jq lintian pkg-config ${{ inputs.deb_extra_build_packages }}
+            apt-get install -y binutils gcc dpkg-dev jq lintian pkg-config zstd ${{ inputs.deb_extra_build_packages }}
             ;;
           centos)
             #sed -i -e 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf || true
             yum install epel-release -y
-            yum install -y findutils gcc jq ${{ inputs.rpm_extra_build_packages }}
+            yum install -y findutils gcc jq zstd ${{ inputs.rpm_extra_build_packages }}
 
             # note: we also install python magic otherwise binaries are not identified as such and rpmlint outputs:
             #   E: no-binary

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -807,21 +807,21 @@ jobs:
 
     # Speed up tooling installation by only re-downloading and re-building dependent crates if we change the version of
     # the tool that we are using.
-    - name: Cache Cargo Deb if available
+    - name: Fetch cargo-deb from cache
       id: cache-cargo-deb
       uses: actions/cache@v3
       with:
         path: ${{ steps.rust.outputs.bin_dir }}/cargo-deb
         key: ${{ matrix.image }}-cargo-deb-${{ env.CARGO_DEB_VER }}-${{ endsWith(matrix.image, 'xenial')}}
 
-    - name: Cache Cargo Generate RPM if available
+    - name: Fetch cargo-generate-rpm from cache
       id: cache-cargo-generate-rpm
       uses: actions/cache@v3
       with:
         path: ${{ steps.rust.outputs.bin_dir }}/cargo-generate-rpm
         key: ${{ matrix.image }}-cargo-generate-rpm-${{ env.CARGO_GENERATE_RPM_VER }}
 
-    - name: Cache TOML-CLI if available
+    - name: Fetch toml-cli from cache
       id: cache-toml-cli
       uses: actions/cache@v3
       with:
@@ -829,7 +829,7 @@ jobs:
         key: ${{ matrix.image }}-toml-cli-${{ env.TOML_CLI_VER }}
 
     # Only install cargo-deb or cargo-generate-rpm if not already fetched from the cache.
-    - name: Install Cargo Deb if needed
+    - name: Install cargo-deb if needed
       if: ${{ steps.cache-cargo-deb.outputs.cache-hit != 'true' }}
       run: |
         case ${OS_NAME} in
@@ -848,7 +848,7 @@ jobs:
             ;;
         esac
 
-    - name: Install Cargo Generate RPM if needed
+    - name: Install cargo-generate-rpm if needed
       if: ${{ steps.cache-cargo-generate-rpm.outputs.cache-hit != 'true' }}
       run: |
         case ${OS_NAME} in
@@ -857,7 +857,7 @@ jobs:
             ;;
         esac
 
-    - name: Install TOML-CLI if needed
+    - name: Install toml-cli if needed
       if: ${{ steps.cache-toml-cli.outputs.cache-hit != 'true' }}
       run: |
         cargo install toml-cli --version ${TOML_CLI_VER}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -836,7 +836,7 @@ jobs:
             else
               EXTRA_CARGO_INSTALL_ARGS=""
             fi
-            cargo install cargo-deb --version ${CARGO_DEB_VER} --locked ${EXTRA_CARGO_INSTALL_ARGS}
+            cargo install cargo-deb --version ${CARGO_DEB_VER} ${EXTRA_CARGO_INSTALL_ARGS}
             ;;
         esac
 
@@ -845,7 +845,7 @@ jobs:
       run: |
         case ${OS_NAME} in
           centos)
-            cargo install cargo-generate-rpm --version ${CARGO_GENERATE_RPM_VER} --locked
+            cargo install cargo-generate-rpm --version ${CARGO_GENERATE_RPM_VER}
             ;;
         esac
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -980,6 +980,8 @@ jobs:
             echo "Generated changelog:"
             cat target/debian/changelog
 
+            sed -i -e "s/\[package.metadata.deb\]/[package.metadata.deb]\nchangelog = \"target\/debian\/changelog\"/" Cargo.toml
+
             #
             # End changelog generation
             #

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -982,7 +982,8 @@ jobs:
 
             #sed -i -e "s/\[package.metadata.deb\]/[package.metadata.deb]\nchangelog = \"target\/debian\/changelog\"/" Cargo.toml
             cargo install toml-cli
-            toml set Cargo.toml package.metadata.deb.changelog target/debian/changelog > Cargo.toml
+            mv Cargo.toml Cargo.toml.org
+            toml set Cargo.toml.org package.metadata.deb.changelog target/debian/changelog > Cargo.toml
             cat Cargo.toml
             
             #

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -747,19 +747,18 @@ jobs:
     # Install Rust the hard way rather than using a GH Action because the action doesn't work inside a Docker container.
     - name: Install Rust
       run: |
-          case ${OS_NAME} in
-            debian|ubuntu)
-              apt-get update
-              apt-get install -y curl
-              ;;
-            centos)
-              ;;
-          esac
+        case ${OS_NAME} in
+          debian|ubuntu)
+            apt-get update
+            apt-get install -y curl
+            ;;
+          centos)
+            ;;
+        esac
 
-          if ! hash cargo; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --profile minimal -y
-            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-          fi
+        if ! hash cargo; then
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --profile minimal -y
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
         fi
 
     - name: Install compilation and other dependencies

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -852,7 +852,7 @@ jobs:
     - name: Install TOML-CLI if needed
       if: ${{ steps.cache-toml-cli.outputs.cache-hit != 'true' }}
       run: |
-        cargo install toml-cli --version ${TOML_CLI_VER} --locked
+        cargo install toml-cli --version ${TOML_CLI_VER}
 
     - name: Download cross-compiled binaries
       if: ${{ matrix.target != 'x86_64' }}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -760,14 +760,16 @@ jobs:
         if ! hash cargo; then
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --profile minimal -y
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          source "$HOME/.cargo/env"
+          echo "bin_dir=$HOME/.cargo/bin" >> $GITHUB_OUTPUT
+        else
+          # Hack to determine the cargo install root directory so that we can tell the correct paths to actions/cache
+          # install a very small cargo "plugin" then find out where it got installed. When using rustup to install Rust
+          # this is likely ~/.cargo/bin, but if using say the rust Docker image then it is a different path entirely.
+          cargo install cargo-list-cache
+          CARGO_BIN_DIR=$(dirname $(which cargo-list-cache))
+          echo "bin_dir=${CARGO_BIN_DIR}" >> $GITHUB_OUTPUT
         fi
-
-        # Hack to determine the cargo install root directory so that we can tell the correct paths to actions/cache
-        # install a very small cargo "plugin" then find out where it got installed. When using rustup to install Rust
-        # this is likely ~/.cargo/bin, but if using say the rust Docker image then it is a different path entirely.
-        cargo install cargo-list-cache
-        CARGO_BIN_DIR=$(dirname $(which cargo-list-cache))
-        echo "bin_dir=${CARGO_BIN_DIR}" >> $GITHUB_OUTPUT
 
     - name: Install compilation and other dependencies
       run: |

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -980,7 +980,9 @@ jobs:
             echo "Generated changelog:"
             cat target/debian/changelog
 
-            sed -i -e "s/\[package.metadata.deb\]/[package.metadata.deb]\nchangelog = \"target\/debian\/changelog\"/" Cargo.toml
+            #sed -i -e "s/\[package.metadata.deb\]/[package.metadata.deb]\nchangelog = \"target\/debian\/changelog\"/" Cargo.toml
+            cargo install toml-cli
+            toml set Cargo.toml package.metadata.deb.changelog target/debian/changelog
             cat Cargo.toml
             
             #

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -778,12 +778,12 @@ jobs:
       run: |
         case ${OS_NAME} in
           debian|ubuntu)
-            apt-get install -y binutils gcc dpkg-dev jq lintian pkg-config zstd ${{ inputs.deb_extra_build_packages }}
+            apt-get install -y binutils gcc dpkg-dev jq lintian pkg-config ${{ inputs.deb_extra_build_packages }}
             ;;
           centos)
             #sed -i -e 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf || true
             yum install epel-release -y
-            yum install -y findutils gcc jq zstd ${{ inputs.rpm_extra_build_packages }}
+            yum install -y findutils gcc jq ${{ inputs.rpm_extra_build_packages }}
 
             # note: we also install python magic otherwise binaries are not identified as such and rpmlint outputs:
             #   E: no-binary

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -766,9 +766,11 @@ jobs:
           # Hack to determine the cargo install root directory so that we can tell the correct paths to actions/cache
           # install a very small cargo "plugin" then find out where it got installed. When using rustup to install Rust
           # this is likely ~/.cargo/bin, but if using say the rust Docker image then it is a different path entirely.
-          # Assume that the crates.io index is up-to-date.
-          cargo install --offline cargo-list-cache
-          CARGO_BIN_DIR=$(dirname $(which cargo-list-cache))
+          # The cargo command should already be installed so this should be almost a no-op. Ideally it would be possible
+          # to just ask cargo but I haven't found a way. The docs list a 5-step process for resolving the bin dir...
+          # (involves checking --root, CARGO_INSTALL_ROOT, install.root, CARGO_HOME and $HOME/.cargo...).
+          # See: https://doc.rust-lang.org/cargo/commands/cargo-install.html#description
+          CARGO_BIN_DIR=$(dirname $(which cargo))
           echo "bin_dir=${CARGO_BIN_DIR}" >> $GITHUB_OUTPUT
         fi
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -746,6 +746,7 @@ jobs:
 
     # Install Rust the hard way rather than using a GH Action because the action doesn't work inside a Docker container.
     - name: Install Rust
+      id: rust
       run: |
         case ${OS_NAME} in
           debian|ubuntu)
@@ -760,6 +761,13 @@ jobs:
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --profile minimal -y
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
         fi
+
+        # Hack to determine the cargo install root directory so that we can tell the correct paths to actions/cache
+        # install a very small cargo "plugin" then find out where it got installed. When using rustup to install Rust
+        # this is likely ~/.cargo/bin, but if using say the rust Docker image then it is a different path entirely.
+        cargo install cargo-list-cache
+        CARGO_BIN_DIR=$(dirname $(which cargo-list-cache))
+        echo "bin_dir=${CARGO_BIN_DIR}" >> $GITHUB_OUTPUT
 
     - name: Install compilation and other dependencies
       run: |
@@ -803,21 +811,21 @@ jobs:
       id: cache-cargo-deb
       uses: actions/cache@v3
       with:
-        path: ~/.cargo/bin/cargo-deb
+        path: ${{ steps.rust.outputs.bin_dir }}/cargo-deb
         key: ${{ matrix.image }}-cargo-deb-${{ env.CARGO_DEB_VER }}-${{ endsWith(matrix.image, 'xenial')}}
 
     - name: Cache Cargo Generate RPM if available
       id: cache-cargo-generate-rpm
       uses: actions/cache@v3
       with:
-        path: ~/.cargo/bin/cargo-generate-rpm
+        path: ${{ steps.rust.outputs.bin_dir }}/cargo-generate-rpm
         key: ${{ matrix.image }}-cargo-generate-rpm-${{ env.CARGO_GENERATE_RPM_VER }}
 
     - name: Cache TOML-CLI if available
       id: cache-toml-cli
       uses: actions/cache@v3
       with:
-        path: ~/.cargo/bin/toml
+        path: ${{ steps.rust.outputs.bin_dir }}/toml
         key: ${{ matrix.image }}-toml-cli-${{ env.TOML_CLI_VER }}
 
     # Only install cargo-deb or cargo-generate-rpm if not already fetched from the cache.

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -982,8 +982,8 @@ jobs:
             GEN_CHANGELOG_PATH="target/debian/changelog"
             SET_CHANGELOG_PATH=$(toml get Cargo.toml ${CHANGELOG_KEY})
 
-            case "${SET_CHANGELOG_PATH}" in
-              null|${GEN_CHANGELOG_PATH})
+            case ${SET_CHANGELOG_PATH} in
+              null|'"'${GEN_CHANGELOG_PATH}'"')
                 #
                 # Generate the changelog file that Debian packages are required to have.
                 # See: https://www.debian.org/doc/manuals/maint-guide/dreq.en.html#changelog

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -747,17 +747,19 @@ jobs:
     # Install Rust the hard way rather than using a GH Action because the action doesn't work inside a Docker container.
     - name: Install Rust
       run: |
-        case ${OS_NAME} in
-          debian|ubuntu)
-            apt-get update
-            apt-get install -y curl
-            ;;
-          centos)
-            ;;
-        esac
+        if ! hash cargo; then
+          case ${OS_NAME} in
+            debian|ubuntu)
+              apt-get update
+              apt-get install -y curl
+              ;;
+            centos)
+              ;;
+          esac
 
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --profile minimal -y
-        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --profile minimal -y
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        fi
 
     - name: Install compilation and other dependencies
       run: |

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -981,7 +981,8 @@ jobs:
             cat target/debian/changelog
 
             sed -i -e "s/\[package.metadata.deb\]/[package.metadata.deb]\nchangelog = \"target\/debian\/changelog\"/" Cargo.toml
-
+            cat Cargo.toml
+            
             #
             # End changelog generation
             #

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -747,7 +747,6 @@ jobs:
     # Install Rust the hard way rather than using a GH Action because the action doesn't work inside a Docker container.
     - name: Install Rust
       run: |
-        if ! hash cargo; then
           case ${OS_NAME} in
             debian|ubuntu)
               apt-get update
@@ -757,8 +756,10 @@ jobs:
               ;;
           esac
 
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --profile minimal -y
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          if ! hash cargo; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --profile minimal -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
         fi
 
     - name: Install compilation and other dependencies

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -982,7 +982,7 @@ jobs:
 
             #sed -i -e "s/\[package.metadata.deb\]/[package.metadata.deb]\nchangelog = \"target\/debian\/changelog\"/" Cargo.toml
             cargo install toml-cli
-            toml set Cargo.toml package.metadata.deb.changelog target/debian/changelog
+            toml set Cargo.toml package.metadata.deb.changelog target/debian/changelog > Cargo.toml
             cat Cargo.toml
             
             #

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -766,7 +766,8 @@ jobs:
           # Hack to determine the cargo install root directory so that we can tell the correct paths to actions/cache
           # install a very small cargo "plugin" then find out where it got installed. When using rustup to install Rust
           # this is likely ~/.cargo/bin, but if using say the rust Docker image then it is a different path entirely.
-          cargo install cargo-list-cache
+          # Assume that the crates.io index is up-to-date.
+          cargo install --offline cargo-list-cache
           CARGO_BIN_DIR=$(dirname $(which cargo-list-cache))
           echo "bin_dir=${CARGO_BIN_DIR}" >> $GITHUB_OUTPUT
         fi


### PR DESCRIPTION
Don't require users who want to create a DEB package to have to add a confusing `changelog = target/debian/changelog` line to their `[package.metadata.deb]` table in their `Cargo.toml` file.

`cargo-deb` needs this line but the user has to add it assuming that Ploutos is going to create the `changelog` file at that location, and they have to use the correction location.

Instead as Ploutos is already capable of generating the file, also have Ploutos generate the missing line in `Cargo.toml` that should refer to the generated file, but only if the user didn't supply a different changelog path of their own.