### PR TITLE
Actions cache save

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -619,6 +619,15 @@ jobs:
       run: |
         cargo install cross
 
+    - name: Force cache save
+      if: ${{ steps.cache-cargo-deb.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@804322aab0a91b60917296129e3ea47efe37cb64
+      with:
+        path: |
+          /home/runner/.cargo/bin/cross
+          /home/runner/.cargo/bin/cross-util
+        key: ${{ matrix.target }}-cargo-cross
+
     - name: Cross compile
       run: |
         cross build --locked --release -v --target ${{ matrix.target }} ${{ inputs.cross_build_args }}
@@ -870,10 +879,24 @@ jobs:
             ;;
         esac
 
+    - name: Force cache save
+      if: ${{ steps.cache-cargo-deb.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@804322aab0a91b60917296129e3ea47efe37cb64
+      with:
+        path: ${{ steps.rust.outputs.bin_dir }}/cargo-generate-rpm
+        key: ${{ matrix.image }}-cargo-generate-rpm-${{ env.CARGO_GENERATE_RPM_VER }}
+
     - name: Install toml-cli if needed
       if: ${{ steps.cache-toml-cli.outputs.cache-hit != 'true' }}
       run: |
         cargo install toml-cli --version ${TOML_CLI_VER}
+
+    - name: Force cache save
+      if: ${{ steps.cache-cargo-deb.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@804322aab0a91b60917296129e3ea47efe37cb64
+      with:
+        path: ${{ steps.rust.outputs.bin_dir }}/toml
+        key: ${{ matrix.image }}-toml-cli-${{ env.TOML_CLI_VER }}
 
     - name: Download cross-compiled binaries
       if: ${{ matrix.target != 'x86_64' }}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -854,6 +854,13 @@ jobs:
             ;;
         esac
 
+    - name: Force cache save
+      if: ${{ steps.cache-cargo-deb.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@804322aab0a91b60917296129e3ea47efe37cb64
+      with:
+        path: ${{ steps.rust.outputs.bin_dir }}/cargo-deb
+        key: ${{ matrix.image }}-cargo-deb-${{ env.CARGO_DEB_VER }}-${{ endsWith(matrix.image, 'xenial')}}
+
     - name: Install cargo-generate-rpm if needed
       if: ${{ steps.cache-cargo-generate-rpm.outputs.cache-hit != 'true' }}
       run: |

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -621,7 +621,7 @@ jobs:
 
     - name: Force cache save
       if: ${{ steps.cache-cargo-deb.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v3.2.0-beta.1
+      uses: actions/cache/save@v3
       with:
         path: |
           /home/runner/.cargo/bin/cross
@@ -865,7 +865,7 @@ jobs:
 
     - name: Force cache save
       if: ${{ steps.cache-cargo-deb.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v3.2.0-beta.1
+      uses: actions/cache/save@v3
       with:
         path: ${{ steps.rust.outputs.bin_dir }}/cargo-deb
         key: ${{ matrix.image }}-cargo-deb-${{ env.CARGO_DEB_VER }}-${{ endsWith(matrix.image, 'xenial')}}
@@ -881,7 +881,7 @@ jobs:
 
     - name: Force cache save
       if: ${{ steps.cache-cargo-deb.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v3.2.0-beta.1
+      uses: actions/cache/save@v3
       with:
         path: ${{ steps.rust.outputs.bin_dir }}/cargo-generate-rpm
         key: ${{ matrix.image }}-cargo-generate-rpm-${{ env.CARGO_GENERATE_RPM_VER }}
@@ -893,7 +893,7 @@ jobs:
 
     - name: Force cache save
       if: ${{ steps.cache-cargo-deb.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v3.2.0-beta.1
+      uses: actions/cache/save@v3
       with:
         path: ${{ steps.rust.outputs.bin_dir }}/toml
         key: ${{ matrix.image }}-toml-cli-${{ env.TOML_CLI_VER }}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -621,8 +621,8 @@ jobs:
 
     - name: Force cache save
       if: ${{ steps.cache-cargo-deb.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@804322aab0a91b60917296129e3ea47efe37cb64
-      with:
+      uses: actions/cache/save@kotewar/save-changes
+        with:
         path: |
           /home/runner/.cargo/bin/cross
           /home/runner/.cargo/bin/cross-util
@@ -865,7 +865,7 @@ jobs:
 
     - name: Force cache save
       if: ${{ steps.cache-cargo-deb.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@804322aab0a91b60917296129e3ea47efe37cb64
+      uses: actions/cache/save@kotewar/save-changes
       with:
         path: ${{ steps.rust.outputs.bin_dir }}/cargo-deb
         key: ${{ matrix.image }}-cargo-deb-${{ env.CARGO_DEB_VER }}-${{ endsWith(matrix.image, 'xenial')}}
@@ -881,7 +881,7 @@ jobs:
 
     - name: Force cache save
       if: ${{ steps.cache-cargo-deb.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@804322aab0a91b60917296129e3ea47efe37cb64
+      uses: actions/cache/save@kotewar/save-changes
       with:
         path: ${{ steps.rust.outputs.bin_dir }}/cargo-generate-rpm
         key: ${{ matrix.image }}-cargo-generate-rpm-${{ env.CARGO_GENERATE_RPM_VER }}
@@ -893,7 +893,7 @@ jobs:
 
     - name: Force cache save
       if: ${{ steps.cache-cargo-deb.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@804322aab0a91b60917296129e3ea47efe37cb64
+      uses: actions/cache/save@kotewar/save-changes
       with:
         path: ${{ steps.rust.outputs.bin_dir }}/toml
         key: ${{ matrix.image }}-toml-cli-${{ env.TOML_CLI_VER }}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -622,7 +622,7 @@ jobs:
     - name: Force cache save
       if: ${{ steps.cache-cargo-deb.outputs.cache-hit != 'true' }}
       uses: actions/cache/save@kotewar/save-changes
-        with:
+      with:
         path: |
           /home/runner/.cargo/bin/cross
           /home/runner/.cargo/bin/cross-util

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -621,7 +621,7 @@ jobs:
 
     - name: Force cache save
       if: ${{ steps.cache-cargo-deb.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@kotewar/save-changes
+      uses: actions/cache/save@v3.2.0-beta.1
       with:
         path: |
           /home/runner/.cargo/bin/cross
@@ -865,7 +865,7 @@ jobs:
 
     - name: Force cache save
       if: ${{ steps.cache-cargo-deb.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@kotewar/save-changes
+      uses: actions/cache/save@v3.2.0-beta.1
       with:
         path: ${{ steps.rust.outputs.bin_dir }}/cargo-deb
         key: ${{ matrix.image }}-cargo-deb-${{ env.CARGO_DEB_VER }}-${{ endsWith(matrix.image, 'xenial')}}
@@ -881,7 +881,7 @@ jobs:
 
     - name: Force cache save
       if: ${{ steps.cache-cargo-deb.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@kotewar/save-changes
+      uses: actions/cache/save@v3.2.0-beta.1
       with:
         path: ${{ steps.rust.outputs.bin_dir }}/cargo-generate-rpm
         key: ${{ matrix.image }}-cargo-generate-rpm-${{ env.CARGO_GENERATE_RPM_VER }}
@@ -893,7 +893,7 @@ jobs:
 
     - name: Force cache save
       if: ${{ steps.cache-cargo-deb.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@kotewar/save-changes
+      uses: actions/cache/save@v3.2.0-beta.1
       with:
         path: ${{ steps.rust.outputs.bin_dir }}/toml
         key: ${{ matrix.image }}-toml-cli-${{ env.TOML_CLI_VER }}


### PR DESCRIPTION
Fixes #47.

[This workflow run](https://github.com/NLnetLabs/ploutos-testing/actions/runs/3703571823/jobs/6533666123) in the ploutos-testing repository shows a successful mix of cache misses followed by the new force cache save step, and successful cache hits (from saves done by steps in other jobs in the same workflow run).