### PR TITLE
v6.2.0

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1145,7 +1145,7 @@ jobs:
             # command line argument.
             if [ -f "${RPM_SCRIPTLETS_PATH}" ]; then
               # Download the RPM systemd macros shell functions file fragment
-              SYSTEMD_RPM_MACROS_URL="https://raw.githubusercontent.com/NLnetLabs/ploutos/v6.1.0/fragments/macros.systemd.sh"
+              SYSTEMD_RPM_MACROS_URL="https://raw.githubusercontent.com/NLnetLabs/ploutos/64-verify-add-support-for-rhel-9-and-derivatives/fragments/macros.systemd.sh"
               SYSTEMD_RPM_MACROS_FILE="/tmp/systemd_rpm_macros"
               curl --proto '=https' --tlsv1.2 --fail --output ${SYSTEMD_RPM_MACROS_FILE} ${SYSTEMD_RPM_MACROS_URL}
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -345,7 +345,7 @@ jobs:
           # would be mostly identical to package_build_rules. If we don't remove this we end up causing duplicate Build
           # jobs to be spawned for each different test mode (fresh-install vs upgrade-from-published) which for the
           # pkb job are identical and thus pointless waste and just plain confusing.
-          PACKAGE_BUILD_RULES_PROCESSED_JSON=$(echo ${PACKAGE_BUILD_RULES_ARRAYS_JSON} | jq -c 'del(.mode) | del(.include[]?.mode)' | del(.test-exclude))
+          PACKAGE_BUILD_RULES_PROCESSED_JSON=$(echo ${PACKAGE_BUILD_RULES_ARRAYS_JSON} | jq -c 'del(.mode) | del(.include[]?.mode)' | del(.testexclude))
 
           echo "package_build_rules<<END_OF_PACKAGE_BUILD_RULES" >> $GITHUB_OUTPUT
           echo ${PACKAGE_BUILD_RULES_PROCESSED_JSON} | jq >> $GITHUB_OUTPUT
@@ -389,8 +389,8 @@ jobs:
             fi
           fi
 
-          # Rename "test-exclude" key to "exclude"
-          PACKAGE_TEST_RULES_PROCESSED_JSON=$(echo ${PACKAGE_TEST_RULES_PROCESSED_JSON} | jq '(.. | select(has("test-exclude")?)) |= with_entries(if .key == "test-exclude" then .key = "exclude" else . end)')
+          # Rename "testexclude" key to "exclude"
+          PACKAGE_TEST_RULES_PROCESSED_JSON=$(echo ${PACKAGE_TEST_RULES_PROCESSED_JSON} | jq '(.. | select(has("testexclude")?)) |= with_entries(if .key == "testexclude" then .key = "exclude" else . end)')
 
           echo "package_test_rules<<END_OF_PACKAGE_TEST_RULES" >> $GITHUB_OUTPUT
           echo ${PACKAGE_TEST_RULES_PROCESSED_JSON} | jq >> $GITHUB_OUTPUT

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -804,7 +804,8 @@ jobs:
                 yum install -y python-magic rpmlint
                 ;;
 
-              8)
+              *)
+                # assume we are only invoked with something newer than CentOS 7, e.g. not CentOS 6 ;-)
                 yum install -y cpio python3-pip
                 pip3 install python-magic rpmlint
                 ;;

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -739,10 +739,10 @@ jobs:
         case ${OS_NAME} in
           debian|ubuntu)
             ;;
-          centos)
+          centos|rockylinux)
             ;;
           *)
-            echo "::error::This workflow only supports 'debian', 'ubuntu' or 'centos' operating systems: '${IMAGE}' is not supported."
+            echo "::error::This workflow only supports 'debian', 'ubuntu', 'centos' or 'rockylinux' operating systems: '${IMAGE}' is not supported."
             exit 1
             ;;
         esac
@@ -765,8 +765,6 @@ jobs:
           debian|ubuntu)
             apt-get update
             apt-get install -y curl
-            ;;
-          centos)
             ;;
         esac
 
@@ -794,7 +792,7 @@ jobs:
           debian|ubuntu)
             apt-get install -y binutils gcc dpkg-dev jq lintian pkg-config ${{ inputs.deb_extra_build_packages }}
             ;;
-          centos)
+          centos|rockylinux)
             #sed -i -e 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf || true
             yum install epel-release -y
             yum install -y findutils gcc jq ${{ inputs.rpm_extra_build_packages }}
@@ -881,7 +879,7 @@ jobs:
       if: ${{ steps.cache-cargo-generate-rpm.outputs.cache-hit != 'true' }}
       run: |
         case ${OS_NAME} in
-          centos)
+          centos|rockylinux)
             cargo install cargo-generate-rpm --version ${CARGO_GENERATE_RPM_VER}
             echo "installed=true" >> $GITHUB_OUTPUT
             ;;
@@ -1073,7 +1071,7 @@ jobs:
             cargo deb --deb-version ${DEB_VER} ${OPT_VARIANT_ARG} -v ${EXTRA_CARGO_DEB_ARGS} -- --locked ${EXTRA_BUILD_ARGS}
             ;;
 
-          centos)
+          centos|rockylinux)
             # Build and strip our app binaries as cargo generate-rpm doesn't do this for us
             cargo build --release --locked -v ${EXTRA_BUILD_ARGS}
             find target/release -maxdepth 1 -type f -executable | xargs strip -s -v
@@ -1090,12 +1088,9 @@ jobs:
                 # see: https://github.com/cat-in-136/cargo-generate-rpm/issues/30
                 EXTRA_CARGO_GENERATE_RPM_ARGS="--payload-compress gzip"
                 ;;
-              centos:8)
-                EXTRA_CARGO_GENERATE_RPM_ARGS=""
-                ;;
               *)
-                echo "::error::Unsupported matrix image value: '${OS_NAME}:${OS_REL}'"
-                exit 1
+                # assume we are only invoked with something newer than CentOS 7, e.g. not CentOS 6 ;-)
+                EXTRA_CARGO_GENERATE_RPM_ARGS=""
                 ;;
             esac
 
@@ -1217,7 +1212,7 @@ jobs:
             popd
             ;;
 
-          centos)
+          centos|rockylinux)
             ls -la target/generate-rpm/
 
             pushd target/generate-rpm
@@ -1290,7 +1285,7 @@ jobs:
             lintian --allow-root -v ${EXTRA_LINTIAN_ARGS} target/debian/*.deb
             ;;
 
-          centos)
+          centos|rockylinux)
             # cargo generate-rpm creates RPMs that rpmlint considers to have errors so don't use the rpmlint exit code
             # otherwise we will always abort the workflow.
 
@@ -1330,7 +1325,8 @@ jobs:
         EOF
                 ;;
 
-              8)
+              *)
+                # Assume we are only invoked with something newer than CentOS 7, e.g. not CentOS 6 ;-)
                 if [[ "${{ inputs.strict_mode }}" == "true" ]]; then
                   EXTRA_RPMLINT_ARGS="${EXTRA_RPMLINT_ARGS} --strict"
                 fi
@@ -1516,7 +1512,7 @@ jobs:
             sg lxd -c "lxc exec testcon -- apt-get update"
             sg lxd -c "lxc exec testcon -- apt-get install -y -o Dpkg::Options::=\"--force-confnew\" apt-transport-https ca-certificates man sudo wget"
             ;;
-          centos)
+          centos|rockylinux)
             if [[ "${MATRIX_IMAGE}" == "centos:8" ]]; then
               # allow CentOS 8 to continue working now that it is EOL
               # see: https://stackoverflow.com/a/70930049
@@ -1534,7 +1530,7 @@ jobs:
             sg lxd -c "lxc file push ${DEB_FILE} testcon/tmp/"
             echo "PKG_FILE=$(basename $DEB_FILE)" >> $GITHUB_ENV
             ;;
-          centos)
+          centos|rockylinux)
             RPM_FILE=$(ls -1 generate-rpm/*.rpm)
             sg lxd -c "lxc file push ${RPM_FILE} testcon/tmp/"
             echo "PKG_FILE=$(basename $RPM_FILE)" >> $GITHUB_ENV
@@ -1577,7 +1573,7 @@ jobs:
               sg lxd -c "lxc exec testcon -- rm -f ${SAVED_MD5SUMS}"
             fi
             ;;
-          centos)
+          centos|rockylinux)
             if [[ -f '${{ inputs.rpm_yum_repo }}' ]]; then
               sg lxd -c "lxc file push ${{ inputs.rpm_yum_repo }} testcon/etc/yum.repos.d/ploutos.repo"
             else
@@ -1597,7 +1593,7 @@ jobs:
           debian|ubuntu)
             sg lxd -c "lxc exec testcon -- apt-get -y install /tmp/${PKG_FILE}"
             ;;
-          centos)
+          centos|rockylinux)
             sg lxd -c "lxc exec testcon -- yum install -y /tmp/${PKG_FILE}" 2>&1 | tee install.log
             # yum install exits with code 0 even if scriptlets fail, so look for some sign of failure
             ! grep -qE '(err|warn|fail)' install.log
@@ -1622,7 +1618,7 @@ jobs:
             # See https://github.com/NLnetLabs/.github/issues/17 regarding --force-confXXX
             sg lxd -c "lxc exec testcon -- apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install /tmp/${PKG_FILE}"
             ;;
-          centos)
+          centos|rockylinux)
             sg lxd -c "lxc exec testcon -- yum install -y /tmp/${PKG_FILE}" 2>&1 | tee upgrade.log
             # yum install exits with code 0 even if scriptlets fail, so look for some sign of failure
             ! grep -qE '(err|warn|fail)' upgrade.log
@@ -1644,8 +1640,6 @@ jobs:
             SAVED_MD5SUMS="/tmp/${{ steps.verify.outputs.pkg }}-conffiles.md5"
             sg lxd -c "lxc exec testcon -- sh -c '[ ! -f ${SAVED_MD5SUMS} ] || md5sum -c ${SAVED_MD5SUMS}'"
             ;;
-          centos)
-            ;;
         esac
 
     - name: Test the upgraded package
@@ -1662,7 +1656,7 @@ jobs:
           debian|ubuntu)
             sg lxd -c "lxc exec testcon -- apt-get -y remove ${{ steps.verify.outputs.pkg }}"
             ;;
-          centos)
+          centos|rockylinux)
             sg lxd -c "lxc exec testcon -- yum remove -y ${{ steps.verify.outputs.pkg }}" 2>&1 | tee remove.log
             # yum remove exits with code 0 even if scriptlets fail, so look for some sign of failure
             ! grep -qE '(err|warn|fail)' remove.log
@@ -1675,7 +1669,7 @@ jobs:
           debian|ubuntu)
             sg lxd -c "lxc exec testcon -- apt-get -y install /tmp/${PKG_FILE}"
             ;;
-          centos)
+          centos|rockylinux)
             sg lxd -c "lxc exec testcon -- yum install -y /tmp/${PKG_FILE}" 2>&1 | tee reinstall.log
             # yum remove exits with code 0 even if scriptlets fail, so look for some sign of failure
             ! grep -qE '(err|warn|fail)' reinstall.log

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -345,7 +345,7 @@ jobs:
           # would be mostly identical to package_build_rules. If we don't remove this we end up causing duplicate Build
           # jobs to be spawned for each different test mode (fresh-install vs upgrade-from-published) which for the
           # pkb job are identical and thus pointless waste and just plain confusing.
-          PACKAGE_BUILD_RULES_PROCESSED_JSON=$(echo ${PACKAGE_BUILD_RULES_ARRAYS_JSON} | jq -c 'del(.mode) | del(.include[]?.mode)' | del(.testexclude))
+          PACKAGE_BUILD_RULES_PROCESSED_JSON=$(echo ${PACKAGE_BUILD_RULES_ARRAYS_JSON} | jq -c 'del(.mode) | del(.include[]?.mode) | del(.testexclude)')
 
           echo "package_build_rules<<END_OF_PACKAGE_BUILD_RULES" >> $GITHUB_OUTPUT
           echo ${PACKAGE_BUILD_RULES_PROCESSED_JSON} | jq >> $GITHUB_OUTPUT

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -345,7 +345,7 @@ jobs:
           # would be mostly identical to package_build_rules. If we don't remove this we end up causing duplicate Build
           # jobs to be spawned for each different test mode (fresh-install vs upgrade-from-published) which for the
           # pkb job are identical and thus pointless waste and just plain confusing.
-          PACKAGE_BUILD_RULES_PROCESSED_JSON=$(echo ${PACKAGE_BUILD_RULES_ARRAYS_JSON} | jq -c 'del(.test-mode) | del(.include[]?.test-mode) | del(.test-exclude)')
+          PACKAGE_BUILD_RULES_PROCESSED_JSON=$(echo ${PACKAGE_BUILD_RULES_ARRAYS_JSON} | jq -c 'del(."test-mode") | del(.include[]?."test-mode") | del(."test-exclude")')
 
           # And now also for the older names for backward compatibility.
           PACKAGE_BUILD_RULES_PROCESSED_JSON=$(echo ${PACKAGE_BUILD_RULES_PROCESSED_JSON} | jq -c 'del(.mode) | del(.include[]?.mode)')

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -345,7 +345,7 @@ jobs:
           # would be mostly identical to package_build_rules. If we don't remove this we end up causing duplicate Build
           # jobs to be spawned for each different test mode (fresh-install vs upgrade-from-published) which for the
           # pkb job are identical and thus pointless waste and just plain confusing.
-          PACKAGE_BUILD_RULES_PROCESSED_JSON=$(echo ${PACKAGE_BUILD_RULES_ARRAYS_JSON} | jq -c 'del(.test-mode) | del(.include[]?.test-mode)' | del(.test-exclude))
+          PACKAGE_BUILD_RULES_PROCESSED_JSON=$(echo ${PACKAGE_BUILD_RULES_ARRAYS_JSON} | jq -c 'del(.test-mode) | del(.include[]?.test-mode) | del(.test-exclude)')
 
           # And now also for the older names for backward compatibility.
           PACKAGE_BUILD_RULES_PROCESSED_JSON=$(echo ${PACKAGE_BUILD_RULES_PROCESSED_JSON} | jq -c 'del(.mode) | del(.include[]?.mode)')

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -345,7 +345,7 @@ jobs:
           # would be mostly identical to package_build_rules. If we don't remove this we end up causing duplicate Build
           # jobs to be spawned for each different test mode (fresh-install vs upgrade-from-published) which for the
           # pkb job are identical and thus pointless waste and just plain confusing.
-          PACKAGE_BUILD_RULES_PROCESSED_JSON=$(echo ${PACKAGE_BUILD_RULES_ARRAYS_JSON} | jq -c 'del(.mode) | del(.include[]?.mode)')
+          PACKAGE_BUILD_RULES_PROCESSED_JSON=$(echo ${PACKAGE_BUILD_RULES_ARRAYS_JSON} | jq -c 'del(.mode) | del(.include[]?.mode)' | del(.test-exclude))
 
           echo "package_build_rules<<END_OF_PACKAGE_BUILD_RULES" >> $GITHUB_OUTPUT
           echo ${PACKAGE_BUILD_RULES_PROCESSED_JSON} | jq >> $GITHUB_OUTPUT
@@ -388,6 +388,9 @@ jobs:
               PACKAGE_TEST_RULES_PROCESSED_JSON="${MODIFIED_JSON}"
             fi
           fi
+
+          # Rename "test-exclude" key to "exclude"
+          PACKAGE_TEST_RULES_PROCESSED_JSON=$(echo ${PACKAGE_TEST_RULES_PROCESSED_JSON} | jq '(.. | select(has("test-exclude")?)) |= with_entries(if .key == "test-exclude" then .key = "exclude" else . end)')
 
           echo "package_test_rules<<END_OF_PACKAGE_TEST_RULES" >> $GITHUB_OUTPUT
           echo ${PACKAGE_TEST_RULES_PROCESSED_JSON} | jq >> $GITHUB_OUTPUT

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -345,7 +345,10 @@ jobs:
           # would be mostly identical to package_build_rules. If we don't remove this we end up causing duplicate Build
           # jobs to be spawned for each different test mode (fresh-install vs upgrade-from-published) which for the
           # pkb job are identical and thus pointless waste and just plain confusing.
-          PACKAGE_BUILD_RULES_PROCESSED_JSON=$(echo ${PACKAGE_BUILD_RULES_ARRAYS_JSON} | jq -c 'del(.mode) | del(.include[]?.mode) | del(.testexclude)')
+          PACKAGE_BUILD_RULES_PROCESSED_JSON=$(echo ${PACKAGE_BUILD_RULES_ARRAYS_JSON} | jq -c 'del(.test-mode) | del(.include[]?.test-mode)' | del(.test-exclude))
+
+          # And now also for the older names for backward compatibility.
+          PACKAGE_BUILD_RULES_PROCESSED_JSON=$(echo ${PACKAGE_BUILD_RULES_PROCESSED_JSON} | jq -c 'del(.mode) | del(.include[]?.mode)')
 
           echo "package_build_rules<<END_OF_PACKAGE_BUILD_RULES" >> $GITHUB_OUTPUT
           echo ${PACKAGE_BUILD_RULES_PROCESSED_JSON} | jq >> $GITHUB_OUTPUT
@@ -389,8 +392,12 @@ jobs:
             fi
           fi
 
-          # Rename "testexclude" key to "exclude"
-          PACKAGE_TEST_RULES_PROCESSED_JSON=$(echo ${PACKAGE_TEST_RULES_PROCESSED_JSON} | jq '(.. | select(has("testexclude")?)) |= with_entries(if .key == "testexclude" then .key = "exclude" else . end)')
+          # In the test rules, rename "test-mode" key to "mode" and "test-exclude" to "exclude".
+          # 'exclude' is used by GitHub Actions itself, while 'mode' has meaning for us. We're renaming them because
+          # prefixing them with 'test-' when used in the build rules makes it clearer that they relate to generated
+          # default test rules.
+          PACKAGE_TEST_RULES_PROCESSED_JSON=$(echo ${PACKAGE_TEST_RULES_PROCESSED_JSON} | jq '(.. | select(has("test-mode")?)) |= with_entries(if .key == "test-mode" then .key = "mode" else . end)')
+          PACKAGE_TEST_RULES_PROCESSED_JSON=$(echo ${PACKAGE_TEST_RULES_PROCESSED_JSON} | jq '(.. | select(has("test-exclude")?)) |= with_entries(if .key == "test-exclude" then .key = "exclude" else . end)')
 
           echo "package_test_rules<<END_OF_PACKAGE_TEST_RULES" >> $GITHUB_OUTPUT
           echo ${PACKAGE_TEST_RULES_PROCESSED_JSON} | jq >> $GITHUB_OUTPUT

--- a/docs/os_packaging.md
+++ b/docs/os_packaging.md
@@ -218,9 +218,9 @@ Only packages that were built using `package_build_rules` can be tested. By defa
 
 Testing packages is optional. To disable testing of packages completely set `package_test_rules` to `none`.
 
-To test package upgrade you must also supply the `deb_apt_xxx` and/or `rpm_yum_xxx` workflow inputs as needed by your packages. To test upgrade of all built packages without supplying `package_test_rules`, add a `mode` key to the `package_build_rules` matrix with value `upgrade-from-published`.
+To test package upgrade you must also supply the `deb_apt_xxx` and/or `rpm_yum_xxx` workflow inputs as needed by your packages. To test upgrade of all built packages without supplying `package_test_rules`, add a `test-mode` key to the `package_build_rules` matrix with value `upgrade-from-published`.
 
-If you wish to test only a subset of the built packages and/or wish to test package upgrade with only a subset of the packages, then you will need to fully specify the `package_test_rules` input matrix.
+If you wish to test only a subset of the built packages and/or wish to test package upgrade with only a subset of the packages, then you will either need to fully specify the `package_test_rules` input matrix, or add a `test-exclude` key to the `package_build_rules` matrix with values in the form supported by the special GitHub Actions `exclude` key. E.g. you can exclude `test-mode` value `upgrade-from-published` only for a new O/S version which is being packaged for for the first time (and thus has no prior releases to do upgrade testing against) by speciying a subkey of `test-exclude` like `image: rockylinux:9`.
 
 The testing process looks like this:
 


### PR DESCRIPTION
This minor release contains the following changes:

- Add support for specifying exclude entries for the generated default test rules matrix via new matrix field 'test-exclude' in the build rules.
- Rename support for 'mode' in the build rules to 'test-mode' ('mode' is still supported for backward compatibility) to make it clearer that it affects generated default test rules and to be consistent with the new 'test-exclude'.
- Add support for building and testing in the rockylinux:9 Docker and LXC containers.

Successful test runs can be seen here:

- dev branch: https://github.com/NLnetLabs/ploutos-testing/actions/runs/4297888042
- main branch: https://github.com/NLnetLabs/ploutos-testing/actions/runs/4312705610/jobs/7524023525
- release tag: https://github.com/NLnetLabs/ploutos-testing/actions/runs/4312997726
- routinator test: https://github.com/NLnetLabs/routinator/actions/runs/4312992572

Release checklist:

- [x] 1. Create a branch in the RELEASE repo, let's call this the RELEASE branch.
- [x] 2. Change RPM_MACROS_URL in the workflow to point to the new RELEASE branch.
- [x] 3. Create a PR in the RELEASE repo for the RELEASE branch.
- [x] 4. Create a matching branch in the TEST repo, let's call this the TEST branch.
- [x] 5. Make the desired changes to the RELEASE branch.
- [x] 6. In the TEST branch modify `.github/workflows/pkg.yml` so that instead of referring to `pkg-rust.yml@vX` it refers to `pkg-rust.yml@<Git ref of HEAD commit on the TEST branch>` or `pkg-rust.yml@<test branch name>`.
- [x] 7. Create a PR in the `.gihub-testing` repository from the TEST branch to `main`, let's call this the TEST PR.
- [x] 8. Repeat steps 4 and 5 until the the `Packaging` workflow run in the TEST PR passes and behaves as desired.
- [x] 9. Merge the TEST PR to the `main` branch.
- [x] 10. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo against the `main` branch passes and behaves as desired. If not, repeat steps 4-9 until the new TEST PR passes and behaves as desired.
- [x] 11. Create a release tag in the TEST repo with the same release tag as will be used in the RELEASE repo, e.g. v1.2.3. _**Note:** Remember to respect semantic versioning, i.e. if the changes being made are not backward compatible you will need to bump the MAJOR version (in MAJOR.MINOR.PATCH) **and** any workflows that invoke the reusable workflow will need to be **manually edited** to refer to the new MAJOR version._
- [x] 12. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo passes against the newly created release tag passes and behaves as desired. If not, delete the release tag **in the TEST repo** and repeat steps 4-11 until the new TEST PR passes and behaves as desired.
- [x] 13. Merge the RELEASE PR to the `main` branch.
- [ ] 14. Change RPM_MACROS_URL in the workflow to point to vX.Y.Z tag (if your release branch has a different name).
- [ ] 15. Create the new release vX.Y.Z tag in the RELEASE repo.
- [ ] 16. Update the vX tag in the RELEASE repo to point to the new vX.Y.Z tag ([howto](https://github.com/NLnetLabs/ploutos/blob/main/docs/develop/README.md#release-process)).
- [ ] 17. Edit `.github/workflows/pkg.yml` in the `main` branch of the TEST repo to refer again to `@vX`.
- [ ] 18. Verify that the `Packaging` action in the TEST repo against the `main` branch passes and works as desired.
- [ ] 19. (optional) If the MAJOR version was changed, update affected repositories that use the reusable workflow to use the new MAJOR version, including adjusting to any breaking changes introduced by the MAJOR version change.
