### PR TITLE
v6.3.0

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1467,8 +1467,8 @@ jobs:
         echo "OS_NAME=${OS_NAME}" >> $GITHUB_ENV
         echo "OS_REL=${OS_REL}" >> $GITHUB_ENV
 
-        if [[ '${{ steps.verify.outputs.test_image }}' != '' ]]; then
-          echo "LXC_IMAGE=images:${{ steps.verify.outputs.test_image }}/cloud" >> $GITHUB_ENV
+        if [[ '${{ matrix.test_image }}' != '' ]]; then
+          echo "LXC_IMAGE=images:${{ matrix.test_image }}/cloud" >> $GITHUB_ENV
         else
           case ${MATRIX_IMAGE} in
             centos:8)

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1468,8 +1468,8 @@ jobs:
         echo "OS_NAME=${OS_NAME}" >> $GITHUB_ENV
         echo "OS_REL=${OS_REL}" >> $GITHUB_ENV
 
-        if [[ '${{ matrix.test_image }}' != '' ]]; then
-          echo "LXC_IMAGE=images:${{ matrix.test_image }}/cloud" >> $GITHUB_ENV
+        if [[ '${{ matrix.test-image }}' != '' ]]; then
+          echo "LXC_IMAGE=images:${{ matrix.test-image }}/cloud" >> $GITHUB_ENV
         else
           case ${MATRIX_IMAGE} in
             centos:8)

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1467,7 +1467,7 @@ jobs:
         echo "OS_NAME=${OS_NAME}" >> $GITHUB_ENV
         echo "OS_REL=${OS_REL}" >> $GITHUB_ENV
 
-        if [[ '${{ steps.verify.outputs.test_image }' != '' ]]; then
+        if [[ '${{ steps.verify.outputs.test_image }}' != '' ]]; then
           echo "LXC_IMAGE=images:${{ steps.verify.outputs.test_image }}/cloud" >> $GITHUB_ENV
         else
           case ${MATRIX_IMAGE} in

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1469,7 +1469,13 @@ jobs:
         echo "OS_REL=${OS_REL}" >> $GITHUB_ENV
 
         if [[ '${{ matrix.test-image }}' != '' ]]; then
-          echo "LXC_IMAGE=images:${{ matrix.test-image }}/cloud" >> $GITHUB_ENV
+          # convert os_name:os_rel to os_name/os_rel. The colon form is consistent with the values the user must
+          # otherwise provide as input, e.g. via the 'image' matrix entry, but LXC images separate the image name
+          # from the image release using a forward slash rather than a colon so we have to convert.
+          TEST_IMAGE="${{ matrix.test-image }}"
+          LXC_IMAGE_NAME=${TEST_IMAGE%:*}
+          LXC_IMAGE_REL=${TEST_IMAGE#*:}
+          echo "LXC_IMAGE=images:${LXC_IMAGE_NAME}/${LXC_IMAGE_REL}/cloud" >> $GITHUB_ENV
         else
           case ${MATRIX_IMAGE} in
             centos:8)

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1467,8 +1467,8 @@ jobs:
         echo "OS_NAME=${OS_NAME}" >> $GITHUB_ENV
         echo "OS_REL=${OS_REL}" >> $GITHUB_ENV
 
-        if [[ '${steps.verify.outputs.test_image}' != '' ]]; then
-          echo "LXC_IMAGE=images:${steps.verify.outputs.test_image}/cloud" >> $GITHUB_ENV
+        if [[ '${{ steps.verify.outputs.test_image }' != '' ]]; then
+          echo "LXC_IMAGE=images:${{ steps.verify.outputs.test_image }}/cloud" >> $GITHUB_ENV
         else
           case ${MATRIX_IMAGE} in
             centos:8)

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1467,16 +1467,20 @@ jobs:
         echo "OS_NAME=${OS_NAME}" >> $GITHUB_ENV
         echo "OS_REL=${OS_REL}" >> $GITHUB_ENV
 
-        case ${MATRIX_IMAGE} in
-          centos:8)
-            # the CentOS 8 LXD image no longer exists since CentOS 8 hit EOL.
-            # use the Rocky Linux (a CentOS 8 compatible O/S) LXD image instead.
-            echo "LXC_IMAGE=images:rockylinux/8/cloud" >> $GITHUB_ENV
-            ;;
-          *)
-            echo "LXC_IMAGE=images:${OS_NAME}/${OS_REL}/cloud" >> $GITHUB_ENV
-            ;;
-        esac
+        if [[ '${steps.verify.outputs.test_image}' != '' ]]; then
+          echo "LXC_IMAGE=images:${steps.verify.outputs.test_image}/cloud" >> $GITHUB_ENV
+        else
+          case ${MATRIX_IMAGE} in
+            centos:8)
+              # the CentOS 8 LXD image no longer exists since CentOS 8 hit EOL.
+              # use the Rocky Linux (a CentOS 8 compatible O/S) LXD image instead.
+              echo "LXC_IMAGE=images:rockylinux/8/cloud" >> $GITHUB_ENV
+              ;;
+            *)
+              echo "LXC_IMAGE=images:${OS_NAME}/${OS_REL}/cloud" >> $GITHUB_ENV
+              ;;
+          esac
+        fi
 
     - name: Download package
       uses: actions/download-artifact@v3

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -346,6 +346,7 @@ jobs:
           # jobs to be spawned for each different test mode (fresh-install vs upgrade-from-published) which for the
           # pkb job are identical and thus pointless waste and just plain confusing.
           PACKAGE_BUILD_RULES_PROCESSED_JSON=$(echo ${PACKAGE_BUILD_RULES_ARRAYS_JSON} | jq -c 'del(."test-mode") | del(.include[]?."test-mode") | del(."test-exclude")')
+          PACKAGE_BUILD_RULES_PROCESSED_JSON=$(echo ${PACKAGE_BUILD_RULES_PROCESSED_JSON} | jq -c 'del(."test-image") | del(.include[]?."test-image")')
 
           # And now also for the older names for backward compatibility.
           PACKAGE_BUILD_RULES_PROCESSED_JSON=$(echo ${PACKAGE_BUILD_RULES_PROCESSED_JSON} | jq -c 'del(.mode) | del(.include[]?.mode)')

--- a/docs/os_packaging.md
+++ b/docs/os_packaging.md
@@ -194,6 +194,12 @@ A rules [matrix](./key_concepts_and_config.md#matrix-rules) with the following k
 | `rpm_systemd_service_unit_file` | No | Relative path to the systemd file, or files (if it ends with `*`) to inclde in an RPM package. See below for more info. |
 | `rpm_rpmlint_check_filters` | No | A space separated set of additional rpmlint checks to filter out. See https://fedoraproject.org/wiki/Common_Rpmlint_issues for some example check names, e.g. `no-documentation`. |
 
+The following keys are special and only relate to the package testing phase when `package_test_rules` value has been supplied. These keys will be removed from `package_build_rules` before the package building phase, but will be preserved in `package_test_rules` for the package testing phase.
+
+| `test-exclude` | No | Sets the GitHub Actions matrix `exclude` key in the `package_test_rules` matrix. |
+| `test-image` | No | Sets the `test-image` key in the `package_test_rules` matrix. See below for more information. |
+| `test-mode` | No | Sets the `mode` key in the `package_test_rules` matrix. See below for more information. |
+
 **Note:** When `package_test_rules` is not supplied the `package_build_rules` matrix is also used as the `package_test_rules` matrix, since normally you want to test every package that you build. When using `package_build_rules` this way you can also supply `package_test_rules` matrix keys in the `package_build_rules` input. These will be ignored by the package building workflow job.
 
 #### Permitted `<image>` values
@@ -213,9 +219,9 @@ It may not matter which O/S release the RPM or DEB package is built inside, exce
 
 ### Package test rules
 
-`package_test_rules` instructs Ploutos to test your packages (beyond the basic verification done post-build).
+`package_test_rules` instructs Ploutos to test your packages (beyond the basic verification done post-build). If not specified, and not disabled, `package_build_rules` will be used as the default input for `package_test_rules`.
 
-Only packages that were built using `package_build_rules` can be tested. By default the packages built according to  `package_build_rules` will be tested, minus any packages for which testing is not supported (e.g. missing LXC image or unsupported architecture).
+Only packages that were built using `package_build_rules` can be tested. By default the packages built according to `package_build_rules` will be tested, minus any packages for which testing is not supported (e.g. missing LXC image or unsupported architecture).
 
 Testing packages is optional. To disable testing of packages completely set `package_test_rules` to `none`.
 
@@ -253,6 +259,7 @@ A rules [matrix](./key_concepts_and_config.md#matrix-rules) with the following k
 | `target` | Yes | The target the package was built for. Must match the value used with `package_build_rules`. |
 | `mode` | Yes | One of: `fresh-install` or `upgrade-from-published` _(assumes a previous version is available in the default package repositories)_. |
 | `ignore_upgrade_failure` | No | If package upgrade fails should this be ignored? (default: false). Ignoring an upgrade can be necessary when a prior release has a bug in the scripts that are run when the package is upgraded, otherwise the `pkg-test` job will fail. |
+| `test-image` | No | An LXC distribution and release pair separated by a colon ':' character. See http://images.linuxcontainers.org/ for possible values. Note that only 'cloud' variants are supported. The LXC container launched will run this image instead of `image`, thereby allowing you to test the package built for the `image` O/S in a different but assumed to be compatible O/S, e.g. test Rocky Linux 9 packages in Alma Linux 9 or CentOS 9 Stream. |
 
 ### Package test script inputs
 


### PR DESCRIPTION
This release contains the following changes:

- Support for a new `package_test_rules` matrix key (also usable in `package_build_rules` when no `package_test_rules` are specified) called `test-image` which can used to test the package in a different O/S than it was built in, e.g. test a Rocky Linux 9 package in Alma Linux 9 or CentOS Stream 9.

Successful test runs can be seen here:

- dev branch: https://github.com/NLnetLabs/ploutos-testing/actions/runs/4318134248
- main branch: https://github.com/NLnetLabs/ploutos-testing/actions/runs/4318230346
- release tag: https://github.com/NLnetLabs/ploutos-testing/actions/runs/4318964877
- routinator: https://github.com/NLnetLabs/routinator/actions/runs/4317919987

Release checklist:

- [x] 1. Create a branch in the RELEASE repo, let's call this the RELEASE branch.
- [ ] 2. Change RPM_MACROS_URL in the workflow to point to the new RELEASE branch.
- [x] 3. Create a PR in the RELEASE repo for the RELEASE branch.
- [x] 4. Create a matching branch in the TEST repo, let's call this the TEST branch.
- [x] 5. Make the desired changes to the RELEASE branch.
- [x] 6. In the TEST branch modify `.github/workflows/pkg.yml` so that instead of referring to `pkg-rust.yml@vX` it refers to `pkg-rust.yml@<Git ref of HEAD commit on the TEST branch>` or `pkg-rust.yml@<test branch name>`.
- [x] 7. Create a PR in the `.gihub-testing` repository from the TEST branch to `main`, let's call this the TEST PR.
- [x] 8. Repeat steps 4 and 5 until the the `Packaging` workflow run in the TEST PR passes and behaves as desired.
- [x] 9. Merge the TEST PR to the `main` branch.
- [x] 10. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo against the `main` branch passes and behaves as desired. If not, repeat steps 4-9 until the new TEST PR passes and behaves as desired.
- [x] 11. Create a release tag in the TEST repo with the same release tag as will be used in the RELEASE repo, e.g. v1.2.3. _**Note:** Remember to respect semantic versioning, i.e. if the changes being made are not backward compatible you will need to bump the MAJOR version (in MAJOR.MINOR.PATCH) **and** any workflows that invoke the reusable workflow will need to be **manually edited** to refer to the new MAJOR version._
- [x] 12. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo passes against the newly created release tag passes and behaves as desired. If not, delete the release tag **in the TEST repo** and repeat steps 4-11 until the new TEST PR passes and behaves as desired.
- [x] 13. Merge the RELEASE PR to the `main` branch.
- [ ] 14. Change RPM_MACROS_URL in the workflow to point to vX.Y.Z tag (if your release branch has a different name).
- [ ] 15. Create the new release vX.Y.Z tag in the RELEASE repo.
- [ ] 16. Update the vX tag in the RELEASE repo to point to the new vX.Y.Z tag ([howto](https://github.com/NLnetLabs/ploutos/blob/main/docs/develop/README.md#release-process)).
- [ ] 17. Edit `.github/workflows/pkg.yml` in the `main` branch of the TEST repo to refer again to `@vX`.
- [ ] 18. Verify that the `Packaging` action in the TEST repo against the `main` branch passes and works as desired.
- [ ] 19. (optional) If the MAJOR version was changed, update affected repositories that use the reusable workflow to use the new MAJOR version, including adjusting to any breaking changes introduced by the MAJOR version change.
