### PR TITLE
Support virtual manifests

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1437,7 +1437,6 @@ jobs:
         addFilter(".: no-group-tag")
         addFilter(".: no-packager-tag")
         addFilter(".: no-signature")
-        addFilter(".: no-url-tag")
         EOF
 
                 # rpmlint 2.x requires that we explicitly tell it where the config file is, and the pip installed

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -295,6 +295,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       cargo_name: ${{ steps.verify_inputs.outputs.cargo_name }}
+      cargo_package_toml_path: ${{ steps.verify_inputs.outputs.cargo_package_toml_path }}
       cargo_manifest_path_arg: ${{ steps.verify_inputs.outputs.cargo_manifest_path_arg }}
       cargo_read_manifest_path_arg: ${{ steps.verify_inputs.outputs.cargo_read_manifest_path_arg }}
       cargo_workspace_package_arg: ${{ steps.verify_inputs.outputs.cargo_workspace_package_arg }}
@@ -492,6 +493,35 @@ jobs:
       - name: Verify inputs
         id: verify_inputs
         run: |
+          CARGO_MANIFEST_PATH_ARG=""
+          if [[ "${{ inputs.manifest_dir}}" != '' ]]; then
+            CARGO_MANIFEST_PATH_ARG="--manifest-path ${{ inputs.manifest_dir }}/Cargo.toml"
+          fi
+          echo "cargo_manifest_path_arg=${CARGO_MANIFEST_PATH_ARG}" >> $GITHUB_OUTPUT
+
+          CARGO_WORKSPACE_PACKAGE_ARG=""
+          if [[ "${{ inputs.workspace_package}}" != '' ]]; then
+            CARGO_WORKSPACE_PACKAGE_ARG="--package ${{ inputs.workspace_package }}"
+          fi
+          echo "cargo_workspace_package_arg=${CARGO_WORKSPACE_PACKAGE_ARG}" >> $GITHUB_OUTPUT
+
+          CARGO_PACKAGE_TOML_PATH="Cargo.toml"
+          CARGO_READ_MANIFEST_PATH_ARG=""
+          if [[ '${{ inputs.manifest_dir}}' != '' ]]; then
+            CARGO_PACKAGE_TOML_PATH="${{ inputs.manifest_dir }}"
+            if [[ '${{ inputs.workspace_package}}' != '' ]]; then
+              CARGO_PACKAGE_TOML_PATH="${CARGO_PACKAGE_TOML_PATH}/${{ inputs.workspace_package}}"
+            fi
+            CARGO_PACKAGE_TOML_PATH="${CARGO_PACKAGE_TOML_PATH}/Cargo.toml"
+            CARGO_READ_MANIFEST_PATH_ARG="--manifest-path ${CARGO_PACKAGE_TOML_PATH}"
+          fi
+
+          echo "cargo_package_toml_path=${CARGO_PACKAGE_TOML_PATH}" >> $GITHUB_OUTPUT
+          echo "cargo_read_manifest_path_arg=${CARGO_READ_MANIFEST_PATH_ARG}" >> $GITHUB_OUTPUT
+
+          CARGO_NAME=$(cat ${CARGO_PACKAGE_TOML_PATH} | docker run --rm -i sclevine/yj -tj | jq -r .package.name)
+          echo "cargo_name=${CARGO_NAME}" >> $GITHUB_OUTPUT
+
           if [[ '${{ inputs.next_ver_label }}' == '' ]]; then
             echo "::error::Workflow input 'next_ver_label' must be non-empty if set."
             exit 1
@@ -521,31 +551,6 @@ jobs:
           else
             echo "has_docker_secrets=false" >> $GITHUB_OUTPUT
           fi
-
-          CARGO_NAME=$(cat Cargo.toml | docker run --rm -i sclevine/yj -tj | jq -r .package.name)
-          echo "cargo_name=${CARGO_NAME}" >> $GITHUB_OUTPUT
-
-          CARGO_MANIFEST_PATH_ARG=""
-          if [[ "${{ inputs.manifest_dir}}" != '' ]]; then
-            CARGO_MANIFEST_PATH_ARG="--manifest-path ${{ inputs.manifest_dir }}/Cargo.toml"
-          fi
-          echo "cargo_manifest_path_arg=${CARGO_MANIFEST_PATH_ARG}" >> $GITHUB_OUTPUT
-
-          CARGO_WORKSPACE_PACKAGE_ARG=""
-          if [[ "${{ inputs.workspace_package}}" != '' ]]; then
-            CARGO_WORKSPACE_PACKAGE_ARG="--package ${{ inputs.workspace_package }}"
-          fi
-          echo "cargo_workspace_package_arg=${CARGO_WORKSPACE_PACKAGE_ARG}" >> $GITHUB_OUTPUT
-
-          CARGO_READ_MANIFEST_PATH_ARG=""
-          if [[ '${{ inputs.manifest_dir}}' != '' ]]; then
-            CARGO_READ_MANIFEST_PATH_ARG="--manifest-path ${{ inputs.manifest_dir }}"
-            if [[ '${{ inputs.workspace_package}}' != '' ]]; then
-              CARGO_READ_MANIFEST_PATH_ARG="${CARGO_READ_MANIFEST_PATH_ARG}/${{ inputs.workspace_package}}"
-            fi
-            CARGO_READ_MANIFEST_PATH_ARG="${CARGO_READ_MANIFEST_PATH_ARG}/Cargo.toml"
-          fi
-          echo "cargo_read_manifest_path_arg=${CARGO_READ_MANIFEST_PATH_ARG}" >> $GITHUB_OUTPUT
 
       - name: Verify Docker credentials
         if: ${{ steps.pre_process_rules.outputs.docker_build_rules != '{}' && fromJSON(steps.verify_inputs.outputs.has_docker_secrets) == true }}
@@ -1056,7 +1061,7 @@ jobs:
 
             OPT_VARIANT_ARG=""
             if [[ "${VARIANT}" != "" ]]; then
-              if grep -qF "[package.metadata.deb.variants.${VARIANT}]" Cargo.toml; then
+              if grep -qF "[package.metadata.deb.variants.${VARIANT}]" ${{ needs.prepare.outputs.cargo_package_toml_path }} then
                 OPT_VARIANT_ARG="--variant ${VARIANT}"
               else
                 echo "::notice file=Cargo.toml::Cargo deb variant '${VARIANT}' not found, using defaults instead."
@@ -1065,7 +1070,7 @@ jobs:
 
             CHANGELOG_KEY="package.metadata.deb.changelog"
             GEN_CHANGELOG_PATH="target/debian/changelog"
-            SET_CHANGELOG_PATH=$(toml get Cargo.toml ${CHANGELOG_KEY})
+            SET_CHANGELOG_PATH=$(toml get ${{ needs.prepare.outputs.cargo_package_toml_path }} ${CHANGELOG_KEY})
 
             case ${SET_CHANGELOG_PATH} in
               null|'"'${GEN_CHANGELOG_PATH}'"')
@@ -1101,9 +1106,9 @@ jobs:
                 cat target/debian/changelog
 
                 # 5. Configure cargo-deb to use the generated changelog file
-                mv Cargo.toml Cargo.toml.org
-                toml set Cargo.toml.org package.metadata.deb.changelog target/debian/changelog > Cargo.toml
-              
+                mv ${{ needs.prepare.outputs.cargo_package_toml_path }}  ${{ needs.prepare.outputs.cargo_package_toml_path }}.org
+                toml set ${{ needs.prepare.outputs.cargo_package_toml_path }}.org package.metadata.deb.changelog target/debian/changelog > ${{ needs.prepare.outputs.cargo_package_toml_path }}
+
                 #
                 # End changelog generation
                 #
@@ -1164,12 +1169,13 @@ jobs:
             # settings specified alternate base settings instead of the usual [package.metadata.generate-rpm] base
             # settings.
             RPM_SCRIPTLETS_PATH="${{ inputs.rpm_scriptlets_path }}"
-            if grep -Eq "^\[package\.metadata\.generate-rpm-alt-base-${MATRIX_PKG}\]$" Cargo.toml; then
+            if grep -Eq "^\[package\.metadata\.generate-rpm-alt-base-${MATRIX_PKG}\]$" ${{ needs.prepare.outputs.cargo_package_toml_path }}; then
               if [[ "${RPM_SCRIPTLETS_PATH}" != "" ]]; then
                 RPM_SCRIPTLETS_PATH="${RPM_SCRIPTLETS_PATH}-${MATRIX_PKG}"
               fi
               sed -i -e "s/^\[package\.metadata\.generate-rpm\]/[package.metadata.moved-generate-rpm]/" \
-                     -e "s/^\[package\.metadata\.generate-rpm-alt-base-${MATRIX_PKG}\]/[package.metadata.generate-rpm]/" Cargo.toml
+                     -e "s/^\[package\.metadata\.generate-rpm-alt-base-${MATRIX_PKG}\]/[package.metadata.generate-rpm]/" \
+                     ${{ needs.prepare.outputs.cargo_package_toml_path }}
             fi
 
             # https://github.com/NLnetLabs/krill/issues/907

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -145,10 +145,15 @@ on:
         type: string
         default: '10'
       strict_mode:
-        description: "if true, certain types of potential spurious warning or error that are usually ignored will instead be considered fatal. Defaults to false."
+        description: "If true, certain types of potential spurious warning or error that are usually ignored will instead be considered fatal. Defaults to false."
         required: false
         type: boolean
         default: false
+      manifest_path:
+        description: "If provided, use the Cargo.toml file at the specified path instead of the Cargo.toml in the root directory of the Git clone."
+        required: false
+        type: string
+        default:
 
       package_build_rules:
         description: "A relative path to a YAML file, or a YAML string, containing a GitHub Actions matrix with 'pkg' (your app name), Docker 'image' (image <os>:<rel>), 'target' (x86_64, or a Rust target triple), 'extra_build_args' (optional), 'os' (optional) fields. See also: https://doc.rust-lang.org/nightly/rustc/platform-support.html"
@@ -285,6 +290,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       cargo_name: ${{ steps.verify_inputs.outputs.cargo_name }}
+      cargo_extra_args: ${{ steps.verify_inputs.outputs.cargo_extra_args }}
       has_docker_secrets: ${{ steps.verify_inputs.outputs.has_docker_secrets }}
       all_repo_and_tag_pairs: ${{ steps.encode.outputs.all_repo_and_tag_pairs }}
       first_repo_and_tag_pair: ${{ steps.encode.outputs.first_repo_and_tag_pair }}
@@ -512,6 +518,12 @@ jobs:
           CARGO_NAME=$(cat Cargo.toml | docker run --rm -i sclevine/yj -tj | jq -r .package.name)
           echo "cargo_name=${CARGO_NAME}" >> $GITHUB_OUTPUT
 
+          CARGO_EXTRA_ARGS=""
+          if [[ "${{ inputs.manifest_path}}" != '' ]]; then
+            CARGO_EXTRA_ARGS="--manifest-path ${{ inputs.manifest_path }}"
+          fi
+          echo "cargo_extra_args=${CARGO_EXTRA_ARGS}" >> $GITHUB_OUTPUT
+
       - name: Verify Docker credentials
         if: ${{ steps.pre_process_rules.outputs.docker_build_rules != '{}' && fromJSON(steps.verify_inputs.outputs.has_docker_secrets) == true }}
         uses: docker/login-action@v2
@@ -645,7 +657,7 @@ jobs:
 
     - name: Cross compile
       run: |
-        cross build --locked --release -v --target ${{ matrix.target }} ${{ inputs.cross_build_args }}
+        cross ${{needs.prepare.outputs.cargo_extra_args}} build --locked --release -v --target ${{ matrix.target }} ${{ inputs.cross_build_args }}
 
     - name: Tar the set of created binaries to upload
       run: |
@@ -979,7 +991,7 @@ jobs:
           exit 1
         fi
 
-        APP_VER=$(cargo read-manifest | jq -r '.version')
+        APP_VER=$(cargo ${{needs.prepare.outputs.cargo_extra_args}} read-manifest | jq -r '.version')
         APP_NEW_VER=$(echo $APP_VER | tr '-' '~')
         NEXT_VER_LABEL="${{ inputs.next_ver_label }}"
         PKG_APP_VER=$(echo $APP_NEW_VER | sed -e "s/~$NEXT_VER_LABEL/-$NEXT_VER_LABEL/")
@@ -1047,7 +1059,7 @@ jobs:
                 #    With jq 1.5: del(recurse(.[]?;true)|select(. == null))
                 #    Older systems only have jq 1.5 so we have to use the more verbose construct.
                 V=${VARIANT:-null}
-                MAINTAINER=$(cargo read-manifest | jq -r '[.metadata.deb.variants."'$V'".maintainer, .metadata.deb.maintainer, .authors[0]] | del(recurse(.[]?;true)|select(. == null))[0]')
+                MAINTAINER=$(cargo ${{needs.prepare.outputs.cargo_extra_args}} read-manifest | jq -r '[.metadata.deb.variants."'$V'".maintainer, .metadata.deb.maintainer, .authors[0]] | del(recurse(.[]?;true)|select(. == null))[0]')
 
                 # 2. Generate the RFC 5322 format date by hand instead of using date --rfc-email because that option doesn't
                 #    exist on Ubuntu 16.04 and Debian 9
@@ -1080,12 +1092,12 @@ jobs:
             # This shouldn't be necessary...
             rm -f target/debian/*.deb
 
-            cargo deb --deb-version ${DEB_VER} ${OPT_VARIANT_ARG} -v ${EXTRA_CARGO_DEB_ARGS} -- --locked ${EXTRA_BUILD_ARGS}
+            cargo ${{needs.prepare.outputs.cargo_extra_args}} deb --deb-version ${DEB_VER} ${OPT_VARIANT_ARG} -v ${EXTRA_CARGO_DEB_ARGS} -- --locked ${EXTRA_BUILD_ARGS}
             ;;
 
           centos|rockylinux)
             # Build and strip our app binaries as cargo generate-rpm doesn't do this for us
-            cargo build --release --locked -v ${EXTRA_BUILD_ARGS}
+            cargo ${{needs.prepare.outputs.cargo_extra_args}} build --release --locked -v ${EXTRA_BUILD_ARGS}
             find target/release -maxdepth 1 -type f -executable | xargs strip -s -v
 
             # TODO: It might be possible to replace the hacky copying of the service file below with some clever use of
@@ -1165,7 +1177,7 @@ jobs:
             # This shouldn't be necessary...
             rm -f target/generate-rpm/*.rpm
 
-            cargo generate-rpm \
+            cargo ${{needs.prepare.outputs.cargo_extra_args}} generate-rpm \
                 --set-metadata "version=\"${PKG_APP_VER}\"" \
                 ${SCRIPTLETS} \
                 ${EXTRA_CARGO_GENERATE_RPM_ARGS}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1066,8 +1066,7 @@ jobs:
             # Prefer the "minimal" cargo-deb profile, if one exists in `Cargo.toml`:
             if grep -qF "[package.metadata.deb.variants.${MINIMAL_VARIANT}]" ${{ needs.prepare.outputs.cargo_package_toml_path }}; then
                 case ${OS_REL} in
-                  xenial|bionic)
-                  stretch)
+                  xenial|bionic|stretch)
                     VARIANT="${MINIMAL_VARIANT}"
                     ;;
                 esac
@@ -1357,8 +1356,7 @@ jobs:
             EXTRA_LINTIAN_ARGS="${EXTRA_LINTIAN_ARGS} --suppress-tags manpage-not-compressed-with-max-compression"
 
             case ${OS_REL} in
-              xenial|bionic|focal)
-              stretch|buster)
+              xenial|bionic|focal|stretch|buster)
                 ;;
 
               *)
@@ -1375,8 +1373,7 @@ jobs:
                 focal)
                   ;;
 
-                xenial|bionic)
-                stretch|buster)
+                xenial|bionic|stretch|buster)
                   EXTRA_LINTIAN_ARGS="${EXTRA_LINTIAN_ARGS} --fail-on-warnings"
                   ;;
 
@@ -1386,8 +1383,7 @@ jobs:
               esac
             else
               case ${OS_REL} in
-                xenial|bionic|focal)
-                stretch|buster)
+                xenial|bionic|focal|stretch|buster)
                   ;;
 
                 *)

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1061,7 +1061,7 @@ jobs:
 
             OPT_VARIANT_ARG=""
             if [[ "${VARIANT}" != "" ]]; then
-              if grep -qF "[package.metadata.deb.variants.${VARIANT}]" ${{ needs.prepare.outputs.cargo_package_toml_path }} then
+              if grep -qF "[package.metadata.deb.variants.${VARIANT}]" ${{ needs.prepare.outputs.cargo_package_toml_path }}; then
                 OPT_VARIANT_ARG="--variant ${VARIANT}"
               else
                 echo "::notice file=Cargo.toml::Cargo deb variant '${VARIANT}' not found, using defaults instead."
@@ -1106,7 +1106,7 @@ jobs:
                 cat target/debian/changelog
 
                 # 5. Configure cargo-deb to use the generated changelog file
-                mv ${{ needs.prepare.outputs.cargo_package_toml_path }}  ${{ needs.prepare.outputs.cargo_package_toml_path }}.org
+                mv ${{ needs.prepare.outputs.cargo_package_toml_path }} ${{ needs.prepare.outputs.cargo_package_toml_path }}.org
                 toml set ${{ needs.prepare.outputs.cargo_package_toml_path }}.org package.metadata.deb.changelog target/debian/changelog > ${{ needs.prepare.outputs.cargo_package_toml_path }}
 
                 #

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -505,14 +505,17 @@ jobs:
           fi
           echo "cargo_workspace_package_arg=${CARGO_WORKSPACE_PACKAGE_ARG}" >> $GITHUB_OUTPUT
 
-          CARGO_PACKAGE_TOML_PATH="Cargo.toml"
+          CARGO_PACKAGE_TOML_PATH=""
           CARGO_READ_MANIFEST_PATH_ARG=""
           if [[ '${{ inputs.manifest_dir}}' != '' ]]; then
-            CARGO_PACKAGE_TOML_PATH="${{ inputs.manifest_dir }}"
-            if [[ '${{ inputs.workspace_package}}' != '' ]]; then
-              CARGO_PACKAGE_TOML_PATH="${CARGO_PACKAGE_TOML_PATH}/${{ inputs.workspace_package}}"
-            fi
-            CARGO_PACKAGE_TOML_PATH="${CARGO_PACKAGE_TOML_PATH}/Cargo.toml"
+            CARGO_PACKAGE_TOML_PATH="${{ inputs.manifest_dir }}/"
+          fi
+          if [[ '${{ inputs.workspace_package}}' != '' ]]; then
+            CARGO_PACKAGE_TOML_PATH="${CARGO_PACKAGE_TOML_PATH}${{ inputs.workspace_package}}/"
+          fi
+          CARGO_PACKAGE_TOML_PATH="${CARGO_PACKAGE_TOML_PATH}Cargo.toml"
+
+          if [[ "${CARGO_PACKAGE_TOML_PATH}" != "Cargo.toml"]]; then
             CARGO_READ_MANIFEST_PATH_ARG="--manifest-path ${CARGO_PACKAGE_TOML_PATH}"
           fi
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1118,7 +1118,7 @@ jobs:
                 mv ${{ needs.prepare.outputs.cargo_package_toml_path }} ${{ needs.prepare.outputs.cargo_package_toml_path }}.org
                 toml set \
                   ${{ needs.prepare.outputs.cargo_package_toml_path }}.org \
-                  package.metadata.deb.changelog target/${GEN_CHANGELOG_NAME} > \
+                  package.metadata.deb.changelog ../target/${GEN_CHANGELOG_NAME} > \
                   ${{ needs.prepare.outputs.cargo_package_toml_path }}
 
                 #

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1121,7 +1121,7 @@ jobs:
                 mv ${{ needs.prepare.outputs.cargo_package_toml_path }} ${{ needs.prepare.outputs.cargo_package_toml_path }}.org
                 toml set \
                   ${{ needs.prepare.outputs.cargo_package_toml_path }}.org \
-                  package.metadata.deb.changelog ../target/${GEN_CHANGELOG_NAME} > \
+                  package.metadata.deb.changelog $(readlink -f ${GEN_CHANGELOG_NAME}) > \
                   ${{ needs.prepare.outputs.cargo_package_toml_path }}
 
                 #

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1350,7 +1350,8 @@ jobs:
           debian|ubuntu)
             dpkg --info ${TARGET_DIR}/debian/*.deb
 
-            EXTRA_LINTIAN_ARGS="${{ matrix.deb_extra_lintian_args }}"
+            EXTRA_LINTIAN_ARGS="--suppress-tags poor-compression-in-manual-page" # since cargo-deb was upgraded from 1.38.4 to 1.42.2
+            EXTRA_LINTIAN_ARGS="${EXTRA_LINTIAN_ARGS} ${{ matrix.deb_extra_lintian_args }}"
 
             if [[ "${CROSS_TARGET}" != "x86_64" ]]; then
               EXTRA_LINTIAN_ARGS="${EXTRA_LINTIAN_ARGS} --suppress-tags unstripped-binary-or-object,statically-linked-binary"

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -728,7 +728,7 @@ jobs:
     env:
       CARGO_DEB_VER: 1.38.4
       CARGO_GENERATE_RPM_VER: 0.10.1
-      TOML_CLI_VER: 0.2.0
+      TOML_CLI_VER: 0.2.3
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1351,6 +1351,7 @@ jobs:
             dpkg --info ${TARGET_DIR}/debian/*.deb
 
             EXTRA_LINTIAN_ARGS="${{ matrix.deb_extra_lintian_args }}"
+            EXTRA_LINTIAN_ARGS="${EXTRA_LINTIAN_ARGS} --supress-tags manpage-not-compressed-with-max-compression"
 
             case ${OS_REL} in
               bionic|xenial|buster|stretch)

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1121,7 +1121,7 @@ jobs:
                 mv ${{ needs.prepare.outputs.cargo_package_toml_path }} ${{ needs.prepare.outputs.cargo_package_toml_path }}.org
                 toml set \
                   ${{ needs.prepare.outputs.cargo_package_toml_path }}.org \
-                  package.metadata.deb.changelog $(readlink -f ${GEN_CHANGELOG_NAME}) > \
+                  package.metadata.deb.changelog $(readlink -f ${GEN_CHANGELOG_PATH}) > \
                   ${{ needs.prepare.outputs.cargo_package_toml_path }}
 
                 #

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -657,7 +657,7 @@ jobs:
 
     - name: Cross compile
       run: |
-        cross ${{needs.prepare.outputs.cargo_extra_args}} build --locked --release -v --target ${{ matrix.target }} ${{ inputs.cross_build_args }}
+        cross build ${{needs.prepare.outputs.cargo_extra_args}} --locked --release -v --target ${{ matrix.target }} ${{ inputs.cross_build_args }}
 
     - name: Tar the set of created binaries to upload
       run: |
@@ -991,7 +991,7 @@ jobs:
           exit 1
         fi
 
-        APP_VER=$(cargo ${{needs.prepare.outputs.cargo_extra_args}} read-manifest | jq -r '.version')
+        APP_VER=$(cargo read-manifest ${{needs.prepare.outputs.cargo_extra_args}} | jq -r '.version')
         APP_NEW_VER=$(echo $APP_VER | tr '-' '~')
         NEXT_VER_LABEL="${{ inputs.next_ver_label }}"
         PKG_APP_VER=$(echo $APP_NEW_VER | sed -e "s/~$NEXT_VER_LABEL/-$NEXT_VER_LABEL/")
@@ -1059,7 +1059,7 @@ jobs:
                 #    With jq 1.5: del(recurse(.[]?;true)|select(. == null))
                 #    Older systems only have jq 1.5 so we have to use the more verbose construct.
                 V=${VARIANT:-null}
-                MAINTAINER=$(cargo ${{needs.prepare.outputs.cargo_extra_args}} read-manifest | jq -r '[.metadata.deb.variants."'$V'".maintainer, .metadata.deb.maintainer, .authors[0]] | del(recurse(.[]?;true)|select(. == null))[0]')
+                MAINTAINER=$(cargo read-manifest ${{needs.prepare.outputs.cargo_extra_args}} | jq -r '[.metadata.deb.variants."'$V'".maintainer, .metadata.deb.maintainer, .authors[0]] | del(recurse(.[]?;true)|select(. == null))[0]')
 
                 # 2. Generate the RFC 5322 format date by hand instead of using date --rfc-email because that option doesn't
                 #    exist on Ubuntu 16.04 and Debian 9
@@ -1092,12 +1092,12 @@ jobs:
             # This shouldn't be necessary...
             rm -f target/debian/*.deb
 
-            cargo ${{needs.prepare.outputs.cargo_extra_args}} deb --deb-version ${DEB_VER} ${OPT_VARIANT_ARG} -v ${EXTRA_CARGO_DEB_ARGS} -- --locked ${EXTRA_BUILD_ARGS}
+            cargo deb ${{needs.prepare.outputs.cargo_extra_args}} --deb-version ${DEB_VER} ${OPT_VARIANT_ARG} -v ${EXTRA_CARGO_DEB_ARGS} -- --locked ${EXTRA_BUILD_ARGS}
             ;;
 
           centos|rockylinux)
             # Build and strip our app binaries as cargo generate-rpm doesn't do this for us
-            cargo ${{needs.prepare.outputs.cargo_extra_args}} build --release --locked -v ${EXTRA_BUILD_ARGS}
+            cargo build ${{needs.prepare.outputs.cargo_extra_args}} --release --locked -v ${EXTRA_BUILD_ARGS}
             find target/release -maxdepth 1 -type f -executable | xargs strip -s -v
 
             # TODO: It might be possible to replace the hacky copying of the service file below with some clever use of
@@ -1177,7 +1177,7 @@ jobs:
             # This shouldn't be necessary...
             rm -f target/generate-rpm/*.rpm
 
-            cargo ${{needs.prepare.outputs.cargo_extra_args}} generate-rpm \
+            cargo generate-rpm ${{needs.prepare.outputs.cargo_extra_args}} \
                 --set-metadata "version=\"${PKG_APP_VER}\"" \
                 ${SCRIPTLETS} \
                 ${EXTRA_CARGO_GENERATE_RPM_ARGS}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1066,7 +1066,10 @@ jobs:
             # Prefer the "minimal" cargo-deb profile, if one exists in `Cargo.toml`:
             if grep -qF "[package.metadata.deb.variants.${MINIMAL_VARIANT}]" ${{ needs.prepare.outputs.cargo_package_toml_path }}; then
                 case ${OS_REL} in
-                  xenial|bionic|stretch) VARIANT="${MINIMAL_VARIANT}" ;;
+                  xenial|bionic)
+                  stretch)
+                    VARIANT="${MINIMAL_VARIANT}"
+                    ;;
                 esac
             fi
 
@@ -1354,7 +1357,8 @@ jobs:
             EXTRA_LINTIAN_ARGS="${EXTRA_LINTIAN_ARGS} --suppress-tags manpage-not-compressed-with-max-compression"
 
             case ${OS_REL} in
-              bionic|xenial|buster|stretch)
+              xenial|bionic|focal)
+              stretch|buster)
                 ;;
 
               *)
@@ -1371,7 +1375,8 @@ jobs:
                 focal)
                   ;;
 
-                xenial|bionic|stretch|buster)
+                xenial|bionic)
+                stretch|buster)
                   EXTRA_LINTIAN_ARGS="${EXTRA_LINTIAN_ARGS} --fail-on-warnings"
                   ;;
 
@@ -1381,7 +1386,8 @@ jobs:
               esac
             else
               case ${OS_REL} in
-                focal|xenial|bionic|stretch|buster)
+                xenial|bionic|focal)
+                stretch|buster)
                   ;;
 
                 *)

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -974,6 +974,7 @@ jobs:
     # Instruct cargo-deb or cargo-generate-rpm to build the package based on Cargo.toml settings and command line
     # arguments.
     - name: Create the package
+      id: create
       env:
         MATRIX_PKG: ${{ steps.verify.outputs.pkg }}
         EXTRA_BUILD_ARGS: ${{ matrix.extra_build_args }}
@@ -1024,13 +1025,20 @@ jobs:
         NEXT_VER_LABEL="${{ inputs.next_ver_label }}"
         PKG_APP_VER=$(echo $APP_NEW_VER | sed -e "s/~$NEXT_VER_LABEL/-$NEXT_VER_LABEL/")
 
+        TARGET_DIR="target"
+        if [[ '${{ inputs.manifest_dir }}' != '' ]]; then
+          TARGET_DIR="${{ inputs.manifest_dir }}/target"
+        fi
+        echo "target_dir=${TARGET_DIR}" >> $GITHUB_OUTPUT
+
         case ${OS_NAME} in
           debian|ubuntu)
             # Ugly hack to use an alternate base Cargo Deb configuration so that the selected variant overrides settings
             # in the specified alternate base settings instead of the usual [package.metadata.deb] base settings.
-            if grep -Eq "^\[package\.metadata\.deb_alt_base_${MATRIX_PKG}\]$" Cargo.toml; then
+            if grep -Eq "^\[package\.metadata\.deb_alt_base_${MATRIX_PKG}\]$" ${{ needs.prepare.outputs.cargo_package_toml_path }}; then
               sed -i -e "s/^\[package\.metadata\.deb\]/[package.metadata.moved-deb]/" \
-                     -e "s/^\[package\.metadata\.deb_alt_base_${MATRIX_PKG}\]/[package.metadata.deb]/" Cargo.toml
+                     -e "s/^\[package\.metadata\.deb_alt_base_${MATRIX_PKG}\]/[package.metadata.deb]/" \
+                     ${{ needs.prepare.outputs.cargo_package_toml_path }}
             fi
 
             EXTRA_CARGO_DEB_ARGS=
@@ -1047,13 +1055,13 @@ jobs:
             # manually. The project being packaged can either define a cross-target specific `cargo-deb` profile, or a 
             # "minimal" profile suitable for cross-compiled targets.
             if [[ "${CROSS_TARGET}" != "x86_64" ]]; then
-              EXTRA_CARGO_DEB_ARGS="--no-build --no-strip --target ${CROSS_TARGET} --output target/debian"
+              EXTRA_CARGO_DEB_ARGS="--no-build --no-strip --target ${CROSS_TARGET} --output ${TARGET_DIR}/debian"
               MINIMAL_VARIANT="minimal-cross"
               VARIANT="${OS_NAME}-${OS_REL}-${CROSS_TARGET}"
             fi
 
             # Prefer the "minimal" cargo-deb profile, if one exists in `Cargo.toml`:
-            if grep -qF "[package.metadata.deb.variants.${MINIMAL_VARIANT}]" Cargo.toml; then
+            if grep -qF "[package.metadata.deb.variants.${MINIMAL_VARIANT}]" ${{ needs.prepare.outputs.cargo_package_toml_path }}; then
                 case ${OS_REL} in
                   xenial|bionic|stretch) VARIANT="${MINIMAL_VARIANT}" ;;
                 esac
@@ -1069,7 +1077,7 @@ jobs:
             fi
 
             CHANGELOG_KEY="package.metadata.deb.changelog"
-            GEN_CHANGELOG_PATH="target/debian/changelog"
+            GEN_CHANGELOG_PATH="${TARGET_DIR}/debian/changelog"
             SET_CHANGELOG_PATH=$(toml get ${{ needs.prepare.outputs.cargo_package_toml_path }} ${CHANGELOG_KEY})
 
             case ${SET_CHANGELOG_PATH} in
@@ -1094,20 +1102,23 @@ jobs:
                 RFC5322_TS=$(LC_TIME=en_US.UTF-8 date +'%a, %d %b %Y %H:%M:%S %z')
 
                 # 3. Generate the changelog file that Debian packages are required to have.
-                if [ ! -d target/debian ]; then
-                  mkdir -p target/debian
+                if [ ! -d ${TARGET_DIR}/debian ]; then
+                  mkdir -p ${TARGET_DIR}/debian
                 fi
-                echo "${MATRIX_PKG} (${PKG_APP_VER}) unstable; urgency=medium" >target/debian/changelog
-                echo "  * See: https://github.com/${{ github.repository }}/releases/tag/v${APP_NEW_VER}" >>target/debian/changelog
-                echo " -- maintainer ${MAINTAINER}  ${RFC5322_TS}" >>target/debian/changelog
+                echo "${MATRIX_PKG} (${PKG_APP_VER}) unstable; urgency=medium" > ${GEN_CHANGELOG_PATH}
+                echo "  * See: https://github.com/${{ github.repository }}/releases/tag/v${APP_NEW_VER}" >> ${GEN_CHANGELOG_PATH}
+                echo " -- maintainer ${MAINTAINER}  ${RFC5322_TS}" >> ${GEN_CHANGELOG_PATH}
 
                 # 4. Print the generated changelog for diagnostic purposes
                 echo "Generated changelog:"
-                cat target/debian/changelog
+                cat ${GEN_CHANGELOG_PATH}
 
                 # 5. Configure cargo-deb to use the generated changelog file
                 mv ${{ needs.prepare.outputs.cargo_package_toml_path }} ${{ needs.prepare.outputs.cargo_package_toml_path }}.org
-                toml set ${{ needs.prepare.outputs.cargo_package_toml_path }}.org package.metadata.deb.changelog target/debian/changelog > ${{ needs.prepare.outputs.cargo_package_toml_path }}
+                toml set \
+                  ${{ needs.prepare.outputs.cargo_package_toml_path }}.org \
+                  package.metadata.deb.changelog ${GEN_CHANGELOG_PATH} > \
+                  ${{ needs.prepare.outputs.cargo_package_toml_path }}
 
                 #
                 # End changelog generation
@@ -1118,14 +1129,28 @@ jobs:
             DEB_VER="${PKG_APP_VER}-1${OS_REL}"
 
             # This shouldn't be necessary...
-            rm -f target/debian/*.deb
+            rm -f ${TARGET_DIR}/debian/*.deb
 
-            cargo deb ${{needs.prepare.outputs.cargo_manifest_path_arg}} ${{needs.prepare.outputs.cargo_workspace_package_arg}} --deb-version ${DEB_VER} ${OPT_VARIANT_ARG} -v ${EXTRA_CARGO_DEB_ARGS} -- --locked ${EXTRA_BUILD_ARGS}
+            cargo deb \
+              ${{needs.prepare.outputs.cargo_manifest_path_arg}} \
+              ${{needs.prepare.outputs.cargo_workspace_package_arg}} \
+              --deb-version ${DEB_VER} \
+              ${OPT_VARIANT_ARG} \
+              -v ${EXTRA_CARGO_DEB_ARGS} \
+              -- \
+              --locked \
+              ${EXTRA_BUILD_ARGS}
             ;;
 
           centos|rockylinux)
             # Build and strip our app binaries as cargo generate-rpm doesn't do this for us
-            cargo build ${{needs.prepare.outputs.cargo_manifest_path_arg}} ${{needs.prepare.outputs.cargo_workspace_package_arg}} --release --locked -v ${EXTRA_BUILD_ARGS}
+            cargo build \
+              ${{needs.prepare.outputs.cargo_manifest_path_arg}} \
+              ${{needs.prepare.outputs.cargo_workspace_package_arg}} \
+              --release \
+              --locked \
+              -v \
+              ${EXTRA_BUILD_ARGS}
 
             # TODO: It might be possible to replace the hacky copying of the service file below with some clever use of
             # `--set-metadata` when invoking cargo generate-rpm. Of particular interest is the new `--variant` command
@@ -1158,11 +1183,11 @@ jobs:
             fi
 
             if [ -e "${SYSTEMD_SERVICE_UNIT_FILE}" ]; then
-                mkdir -p target/rpm/
-                cp ${SYSTEMD_SERVICE_UNIT_FILE} target/rpm/${MATRIX_PKG}.service
+                mkdir -p ${TARGET_DIR}/rpm/
+                cp ${SYSTEMD_SERVICE_UNIT_FILE} ${TARGET_DIR}/rpm/${MATRIX_PKG}.service
             elif [[ "${SYSTEMD_SERVICE_UNIT_FILE}" == *"*" ]]; then
-                mkdir -p target/rpm/
-                cp ${SYSTEMD_SERVICE_UNIT_FILE} target/rpm
+                mkdir -p ${TARGET_DIR}/rpm/
+                cp ${SYSTEMD_SERVICE_UNIT_FILE} ${TARGET_DIR}/rpm
             fi
 
             # Ugly hack to use an alternate base Cargo Generate RPM configuration so that the selected variant overrides
@@ -1202,14 +1227,14 @@ jobs:
               SCRIPTLETS='--metadata-overwrite=${{ inputs.rpm_scriptlets_path }}'
             fi
 
+            find ${TARGET_DIR}/release -maxdepth 1 -type f -executable | xargs strip -s -v
+
+            # This shouldn't be necessary...
+            rm -f ${TARGET_DIR}/generate-rpm/*.rpm
+
             if [[ '${{inputs.manifest_dir}}' != '' ]]; then
               pushd ${{inputs.manifest_dir}}
             fi
-
-            find target/release -maxdepth 1 -type f -executable | xargs strip -s -v
-
-            # This shouldn't be necessary...
-            rm -f target/generate-rpm/*.rpm
   
             cargo generate-rpm ${{needs.prepare.outputs.cargo_workspace_package_arg}} \
                 --set-metadata "version=\"${PKG_APP_VER}\"" \
@@ -1225,13 +1250,15 @@ jobs:
 
     - name: Post-process the package
       run: |
+        TARGET_DIR="${{ steps.create.outputs.target_dir}}"
+
         case ${OS_NAME} in
           debian|ubuntu)
             # https://github.com/NLnetLabs/routinator/issues/783
             # Patch the generated DEB to have ./ paths compatible with `unattended-upgrade`:
-            ls -la target/debian/
+            ls -la ${TARGET_DIR}/debian/
 
-            pushd target/debian
+            pushd ${TARGET_DIR}/debian
             DEB_FILE_NAME=$(ls -1 *.deb | head -n 1)
             DATA_ARCHIVE=$(ar t ${DEB_FILE_NAME} | grep -E '^data\.tar')
             ar x ${DEB_FILE_NAME} ${DATA_ARCHIVE}
@@ -1251,9 +1278,9 @@ jobs:
             ar r ${DEB_FILE_NAME} ${DATA_ARCHIVE}
             popd
 
-            ls -la target/debian/
+            ls -la ${TARGET_DIR}/debian/
 
-            pushd target/debian
+            pushd ${TARGET_DIR}/debian
             dpkg -e ${DEB_FILE_NAME} control_files
             dpkg -x ${DEB_FILE_NAME} data_files
 
@@ -1276,9 +1303,9 @@ jobs:
             ;;
 
           centos|rockylinux)
-            ls -la target/generate-rpm/
+            ls -la ${TARGET_DIR}/generate-rpm/
 
-            pushd target/generate-rpm
+            pushd ${TARGET_DIR}/generate-rpm
             for F in *.rpm; do
               echo $F
               mkdir t
@@ -1310,9 +1337,14 @@ jobs:
       env:
         CROSS_TARGET: ${{ matrix.target }}
       run: |
+        TARGET_DIR="${{ steps.create.outputs.target_dir}}"
+        if [[ '${{ inputs.manifest_dir }}' != '' ]]; then
+          TARGET_DIR="${{ inputs.manifest_dir }}/target"
+        fi
+
         case ${OS_NAME} in
           debian|ubuntu)
-            dpkg --info target/debian/*.deb
+            dpkg --info ${TARGET_DIR}/debian/*.deb
 
             EXTRA_LINTIAN_ARGS="${{ matrix.deb_extra_lintian_args }}"
 
@@ -1345,7 +1377,7 @@ jobs:
             fi
 
             lintian --version
-            lintian --allow-root -v ${EXTRA_LINTIAN_ARGS} target/debian/*.deb
+            lintian --allow-root -v ${EXTRA_LINTIAN_ARGS} ${TARGET_DIR}/debian/*.deb
             ;;
 
           centos|rockylinux)
@@ -1425,7 +1457,7 @@ jobs:
             cat ${LINTER_CONFIG_PATH}
 
             rpmlint --version
-            rpmlint ${EXTRA_RPMLINT_ARGS} target/generate-rpm/*.rpm
+            rpmlint ${EXTRA_RPMLINT_ARGS} ${TARGET_DIR}/generate-rpm/*.rpm
             ;;
         esac
 
@@ -1437,8 +1469,8 @@ jobs:
       with:
         name: ${{ inputs.artifact_prefix }}${{ steps.verify.outputs.pkg }}_${{ env.OS_NAME }}_${{ env.OS_REL }}_${{ matrix.target }}
         path: |
-          target/debian/*.deb
-          target/generate-rpm/*.rpm
+          ${{ steps.create.outputs.target_dir }}/debian/*.deb
+          ${{ steps.create.outputs.target_dir }}/generate-rpm/*.rpm
 
   # -------------------------------------------------------------------------------------------------------------------
   # Job: 'pkg-test'

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1350,8 +1350,13 @@ jobs:
           debian|ubuntu)
             dpkg --info ${TARGET_DIR}/debian/*.deb
 
-            EXTRA_LINTIAN_ARGS="--suppress-tags poor-compression-in-manual-page" # since cargo-deb was upgraded from 1.38.4 to 1.42.2
-            EXTRA_LINTIAN_ARGS="${EXTRA_LINTIAN_ARGS} ${{ matrix.deb_extra_lintian_args }}"
+            EXTRA_LINTIAN_ARGS="${{ matrix.deb_extra_lintian_args }}"
+
+            case ${OS_REL} in
+              stretch)
+                EXTRA_LINTIAN_ARGS="${EXTRA_LINTIAN_ARGS} --suppress-tags poor-compression-in-manual-page"
+                ;;
+            esac
 
             if [[ "${CROSS_TARGET}" != "x86_64" ]]; then
               EXTRA_LINTIAN_ARGS="${EXTRA_LINTIAN_ARGS} --suppress-tags unstripped-binary-or-object,statically-linked-binary"

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1205,7 +1205,7 @@ jobs:
             # This shouldn't be necessary...
             rm -f target/generate-rpm/*.rpm
   
-            cargo generate-rpm ${{needs.prepare.outputs.cargo_package_arg}} \
+            cargo generate-rpm ${{needs.prepare.outputs.cargo_workspace_package_arg}} \
                 --set-metadata "version=\"${PKG_APP_VER}\"" \
                 ${SCRIPTLETS} \
                 ${EXTRA_CARGO_GENERATE_RPM_ARGS}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -726,7 +726,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.prepare.outputs.package_build_rules) }}
     env:
-      CARGO_DEB_VER: 1.38.4
+      CARGO_DEB_VER: 1.42.2
       CARGO_GENERATE_RPM_VER: 0.10.1
       TOML_CLI_VER: 0.2.3
     steps:

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1082,7 +1082,7 @@ jobs:
             CHANGELOG_KEY="package.metadata.deb.changelog"
             GEN_CHANGELOG_NAME="debian/changelog"
             GEN_CHANGELOG_PATH="${TARGET_DIR}/${GEN_CHANGELOG_NAME}"
-            SET_CHANGELOG_PATH=$(toml get ${{ needs.prepare.outputs.cargo_package_toml_path }} ${CHANGELOG_KEY})
+            SET_CHANGELOG_PATH=$(toml get ${{ needs.prepare.outputs.cargo_package_toml_path }} ${CHANGELOG_KEY || echo null})
 
             case ${SET_CHANGELOG_PATH} in
               null|'"'${GEN_CHANGELOG_PATH}'"')

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1121,7 +1121,6 @@ jobs:
           centos|rockylinux)
             # Build and strip our app binaries as cargo generate-rpm doesn't do this for us
             cargo build ${{needs.prepare.outputs.cargo_manifest_path_arg}} ${{needs.prepare.outputs.cargo_workspace_package_arg}} --release --locked -v ${EXTRA_BUILD_ARGS}
-            find target/release -maxdepth 1 -type f -executable | xargs strip -s -v
 
             # TODO: It might be possible to replace the hacky copying of the service file below with some clever use of
             # `--set-metadata` when invoking cargo generate-rpm. Of particular interest is the new `--variant` command
@@ -1197,12 +1196,14 @@ jobs:
               SCRIPTLETS='--metadata-overwrite=${{ inputs.rpm_scriptlets_path }}'
             fi
 
-            # This shouldn't be necessary...
-            rm -f target/generate-rpm/*.rpm
-
             if [[ '${{inputs.manifest_dir}}' != '' ]]; then
               pushd ${{inputs.manifest_dir}}
             fi
+
+            find target/release -maxdepth 1 -type f -executable | xargs strip -s -v
+
+            # This shouldn't be necessary...
+            rm -f target/generate-rpm/*.rpm
   
             cargo generate-rpm ${{needs.prepare.outputs.cargo_package_arg}} \
                 --set-metadata "version=\"${PKG_APP_VER}\"" \

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1353,7 +1353,7 @@ jobs:
             EXTRA_LINTIAN_ARGS="${{ matrix.deb_extra_lintian_args }}"
 
             case ${OS_REL} in
-              bionic|buster|stretch)
+              bionic|xenial|buster|stretch)
                 ;;
 
               *)

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -149,11 +149,16 @@ on:
         required: false
         type: boolean
         default: false
-      manifest_path:
-        description: "If provided, use the Cargo.toml file at the specified path instead of the Cargo.toml in the root directory of the Git clone."
+      manifest_dir:
+        description: "The path to a directory containing the Cargo.toml file to use instead of the Cargo.toml in the root directory of the Git clone."
         required: false
         type: string
-        default:
+        default: ''
+      workspace_package:
+        description: "If provided, take [package] settings from the Cargo.toml of this member of the workspace (rooted at manifest_dir, if specified)."
+        required: false
+        type: string
+        default: ''
 
       package_build_rules:
         description: "A relative path to a YAML file, or a YAML string, containing a GitHub Actions matrix with 'pkg' (your app name), Docker 'image' (image <os>:<rel>), 'target' (x86_64, or a Rust target triple), 'extra_build_args' (optional), 'os' (optional) fields. See also: https://doc.rust-lang.org/nightly/rustc/platform-support.html"
@@ -290,7 +295,9 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       cargo_name: ${{ steps.verify_inputs.outputs.cargo_name }}
-      cargo_extra_args: ${{ steps.verify_inputs.outputs.cargo_extra_args }}
+      cargo_manifest_path_arg: ${{ steps.verify_inputs.outputs.cargo_manifest_path_arg }}
+      cargo_read_manifest_path_arg: ${{ steps.verify_inputs.outputs.cargo_read_manifest_path_arg }}
+      cargo_workspace_package_arg: ${{ steps.verify_inputs.outputs.cargo_workspace_package_arg }}
       has_docker_secrets: ${{ steps.verify_inputs.outputs.has_docker_secrets }}
       all_repo_and_tag_pairs: ${{ steps.encode.outputs.all_repo_and_tag_pairs }}
       first_repo_and_tag_pair: ${{ steps.encode.outputs.first_repo_and_tag_pair }}
@@ -518,11 +525,27 @@ jobs:
           CARGO_NAME=$(cat Cargo.toml | docker run --rm -i sclevine/yj -tj | jq -r .package.name)
           echo "cargo_name=${CARGO_NAME}" >> $GITHUB_OUTPUT
 
-          CARGO_EXTRA_ARGS=""
-          if [[ "${{ inputs.manifest_path}}" != '' ]]; then
-            CARGO_EXTRA_ARGS="--manifest-path ${{ inputs.manifest_path }}"
+          CARGO_MANIFEST_PATH_ARG=""
+          if [[ "${{ inputs.manifest_dir}}" != '' ]]; then
+            CARGO_MANIFEST_PATH_ARG="--manifest-path ${{ inputs.manifest_path }}/Cargo.toml"
           fi
-          echo "cargo_extra_args=${CARGO_EXTRA_ARGS}" >> $GITHUB_OUTPUT
+          echo "cargo_manifest_path_arg=${CARGO_MANIFEST_PATH_ARG}" >> $GITHUB_OUTPUT
+
+          CARGO_WORKSPACE_PACKAGE_ARG=""
+          if [[ "${{ inputs.workspace_package}}" != '' ]]; then
+            CARGO_WORKSPACE_PACKAGE_ARG="--package ${{ inputs.workspace_package }}"
+          fi
+          echo "cargo_workspace_package_arg=${CARGO_WORKSPACE_PACKAGE_ARG}" >> $GITHUB_OUTPUT
+
+          CARGO_READ_MANIFEST_PATH_ARG=""
+          if [[ '${{ inputs.manifest_dir}}' != '' ]]; then
+            CARGO_READ_MANIFEST_PATH_ARG="--manifest-path ${{ inputs.manifest_dir }}"
+            if [[ '${{ inputs.workspace_package}}' != '' ]]; then
+              CARGO_READ_MANIFEST_PATH_ARG="${CARGO_READ_MANIFEST_PATH_ARG}/${{ inputs.workspace_package}}"
+            fi
+            CARGO_READ_MANIFEST_PATH_ARG="${CARGO_READ_MANIFEST_PATH_ARG}/Cargo.toml"
+          fi
+          echo "cargo_read_manifest_path_arg=${CARGO_READ_MANIFEST_PATH_ARG}" >> $GITHUB_OUTPUT
 
       - name: Verify Docker credentials
         if: ${{ steps.pre_process_rules.outputs.docker_build_rules != '{}' && fromJSON(steps.verify_inputs.outputs.has_docker_secrets) == true }}
@@ -657,7 +680,7 @@ jobs:
 
     - name: Cross compile
       run: |
-        cross build ${{needs.prepare.outputs.cargo_extra_args}} --locked --release -v --target ${{ matrix.target }} ${{ inputs.cross_build_args }}
+        cross build ${{needs.prepare.outputs.cargo_manifest_path_arg}} ${{needs.prepare.outputs.cargo_workspace_package_arg}} --locked --release -v --target ${{ matrix.target }} ${{ inputs.cross_build_args }}
 
     - name: Tar the set of created binaries to upload
       run: |
@@ -991,7 +1014,7 @@ jobs:
           exit 1
         fi
 
-        APP_VER=$(cargo read-manifest ${{needs.prepare.outputs.cargo_extra_args}} | jq -r '.version')
+        APP_VER=$(cargo read-manifest ${{ needs.prepare.outputs.cargo_read_manifest_path_arg }} | jq -r '.version')
         APP_NEW_VER=$(echo $APP_VER | tr '-' '~')
         NEXT_VER_LABEL="${{ inputs.next_ver_label }}"
         PKG_APP_VER=$(echo $APP_NEW_VER | sed -e "s/~$NEXT_VER_LABEL/-$NEXT_VER_LABEL/")
@@ -1059,7 +1082,7 @@ jobs:
                 #    With jq 1.5: del(recurse(.[]?;true)|select(. == null))
                 #    Older systems only have jq 1.5 so we have to use the more verbose construct.
                 V=${VARIANT:-null}
-                MAINTAINER=$(cargo read-manifest ${{needs.prepare.outputs.cargo_extra_args}} | jq -r '[.metadata.deb.variants."'$V'".maintainer, .metadata.deb.maintainer, .authors[0]] | del(recurse(.[]?;true)|select(. == null))[0]')
+                MAINTAINER=$(cargo read-manifest ${{needs.prepare.outputs.cargo_read_manifest_path_arg}} | jq -r '[.metadata.deb.variants."'$V'".maintainer, .metadata.deb.maintainer, .authors[0]] | del(recurse(.[]?;true)|select(. == null))[0]')
 
                 # 2. Generate the RFC 5322 format date by hand instead of using date --rfc-email because that option doesn't
                 #    exist on Ubuntu 16.04 and Debian 9
@@ -1092,12 +1115,12 @@ jobs:
             # This shouldn't be necessary...
             rm -f target/debian/*.deb
 
-            cargo deb ${{needs.prepare.outputs.cargo_extra_args}} --deb-version ${DEB_VER} ${OPT_VARIANT_ARG} -v ${EXTRA_CARGO_DEB_ARGS} -- --locked ${EXTRA_BUILD_ARGS}
+            cargo deb ${{needs.prepare.outputs.cargo_manifest_path_arg}} ${{needs.prepare.outputs.cargo_workspace_package_arg}} --deb-version ${DEB_VER} ${OPT_VARIANT_ARG} -v ${EXTRA_CARGO_DEB_ARGS} -- --locked ${EXTRA_BUILD_ARGS}
             ;;
 
           centos|rockylinux)
             # Build and strip our app binaries as cargo generate-rpm doesn't do this for us
-            cargo build ${{needs.prepare.outputs.cargo_extra_args}} --release --locked -v ${EXTRA_BUILD_ARGS}
+            cargo build ${{needs.prepare.outputs.cargo_manifest_path_arg}} ${{needs.prepare.outputs.cargo_workspace_package_arg}} --release --locked -v ${EXTRA_BUILD_ARGS}
             find target/release -maxdepth 1 -type f -executable | xargs strip -s -v
 
             # TODO: It might be possible to replace the hacky copying of the service file below with some clever use of
@@ -1177,11 +1200,19 @@ jobs:
             # This shouldn't be necessary...
             rm -f target/generate-rpm/*.rpm
 
-            cargo generate-rpm ${{needs.prepare.outputs.cargo_extra_args}} \
+            if [[ '${{inputs.manifest_dir}}' != '' ]]; then
+              pushd ${{inputs.manifest_dir}}
+            fi
+  
+            cargo generate-rpm ${{needs.prepare.outputs.cargo_package_arg}} \
                 --set-metadata "version=\"${PKG_APP_VER}\"" \
                 ${SCRIPTLETS} \
                 ${EXTRA_CARGO_GENERATE_RPM_ARGS}
             ;;
+
+            if [[ '${{inputs.manifest_dir}}' != '' ]]; then
+              popd
+            fi
         esac
 
     - name: Post-process the package

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1208,11 +1208,12 @@ jobs:
                 --set-metadata "version=\"${PKG_APP_VER}\"" \
                 ${SCRIPTLETS} \
                 ${EXTRA_CARGO_GENERATE_RPM_ARGS}
-            ;;
 
             if [[ '${{inputs.manifest_dir}}' != '' ]]; then
               popd
             fi
+
+            ;;
         esac
 
     - name: Post-process the package

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -507,7 +507,7 @@ jobs:
 
           CARGO_PACKAGE_TOML_PATH=""
           CARGO_READ_MANIFEST_PATH_ARG=""
-          if [[ '${{ inputs.manifest_dir}}' != '' ]]; then
+          if [[ '${{ inputs.manifest_dir }}' != '' ]]; then
             CARGO_PACKAGE_TOML_PATH="${{ inputs.manifest_dir }}/"
           fi
           if [[ '${{ inputs.workspace_package}}' != '' ]]; then
@@ -515,7 +515,7 @@ jobs:
           fi
           CARGO_PACKAGE_TOML_PATH="${CARGO_PACKAGE_TOML_PATH}Cargo.toml"
 
-          if [[ "${CARGO_PACKAGE_TOML_PATH}" != "Cargo.toml"]]; then
+          if [[ "${CARGO_PACKAGE_TOML_PATH}" != "Cargo.toml" ]]; then
             CARGO_READ_MANIFEST_PATH_ARG="--manifest-path ${CARGO_PACKAGE_TOML_PATH}"
           fi
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -727,7 +727,7 @@ jobs:
       matrix: ${{ fromJSON(needs.prepare.outputs.package_build_rules) }}
     env:
       CARGO_DEB_VER: 1.38.4
-      CARGO_GENERATE_RPM_VER: 0.8.0
+      CARGO_GENERATE_RPM_VER: 0.10.1
       TOML_CLI_VER: 0.2.0
     steps:
     - name: Checkout repository

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1077,7 +1077,8 @@ jobs:
             fi
 
             CHANGELOG_KEY="package.metadata.deb.changelog"
-            GEN_CHANGELOG_PATH="${TARGET_DIR}/debian/changelog"
+            GEN_CHANGELOG_NAME="debian/changelog"
+            GEN_CHANGELOG_PATH="${TARGET_DIR}/${GEN_CHANGELOG_NAME}"
             SET_CHANGELOG_PATH=$(toml get ${{ needs.prepare.outputs.cargo_package_toml_path }} ${CHANGELOG_KEY})
 
             case ${SET_CHANGELOG_PATH} in
@@ -1117,7 +1118,7 @@ jobs:
                 mv ${{ needs.prepare.outputs.cargo_package_toml_path }} ${{ needs.prepare.outputs.cargo_package_toml_path }}.org
                 toml set \
                   ${{ needs.prepare.outputs.cargo_package_toml_path }}.org \
-                  package.metadata.deb.changelog ${GEN_CHANGELOG_PATH} > \
+                  package.metadata.deb.changelog target/${GEN_CHANGELOG_NAME} > \
                   ${{ needs.prepare.outputs.cargo_package_toml_path }}
 
                 #

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1354,6 +1354,9 @@ jobs:
 
             case ${OS_REL} in
               stretch)
+                ;;
+
+              *)
                 EXTRA_LINTIAN_ARGS="${EXTRA_LINTIAN_ARGS} --suppress-tags poor-compression-in-manual-page"
                 ;;
             esac

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1353,7 +1353,7 @@ jobs:
             EXTRA_LINTIAN_ARGS="${{ matrix.deb_extra_lintian_args }}"
 
             case ${OS_REL} in
-              stretch)
+              bionic|buster|stretch)
                 ;;
 
               *)

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -527,7 +527,7 @@ jobs:
 
           CARGO_MANIFEST_PATH_ARG=""
           if [[ "${{ inputs.manifest_dir}}" != '' ]]; then
-            CARGO_MANIFEST_PATH_ARG="--manifest-path ${{ inputs.manifest_path }}/Cargo.toml"
+            CARGO_MANIFEST_PATH_ARG="--manifest-path ${{ inputs.manifest_dir }}/Cargo.toml"
           fi
           echo "cargo_manifest_path_arg=${CARGO_MANIFEST_PATH_ARG}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1351,7 +1351,7 @@ jobs:
             dpkg --info ${TARGET_DIR}/debian/*.deb
 
             EXTRA_LINTIAN_ARGS="${{ matrix.deb_extra_lintian_args }}"
-            EXTRA_LINTIAN_ARGS="${EXTRA_LINTIAN_ARGS} --supress-tags manpage-not-compressed-with-max-compression"
+            EXTRA_LINTIAN_ARGS="${EXTRA_LINTIAN_ARGS} --suppress-tags manpage-not-compressed-with-max-compression"
 
             case ${OS_REL} in
               bionic|xenial|buster|stretch)

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1082,7 +1082,7 @@ jobs:
             CHANGELOG_KEY="package.metadata.deb.changelog"
             GEN_CHANGELOG_NAME="debian/changelog"
             GEN_CHANGELOG_PATH="${TARGET_DIR}/${GEN_CHANGELOG_NAME}"
-            SET_CHANGELOG_PATH=$(toml get ${{ needs.prepare.outputs.cargo_package_toml_path }} ${CHANGELOG_KEY || echo null})
+            SET_CHANGELOG_PATH=$(toml get ${{ needs.prepare.outputs.cargo_package_toml_path }} ${CHANGELOG_KEY} || echo null)
 
             case ${SET_CHANGELOG_PATH} in
               null|'"'${GEN_CHANGELOG_PATH}'"')

--- a/docs/key_concepts_and_config.md
+++ b/docs/key_concepts_and_config.md
@@ -141,7 +141,7 @@ Some actions performed by Ploutos can result in warnings or errors that are pote
 
 ## Cargo workspace support
 
-A Rust Cargo "workspace" (see [here](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html) and [here](https://doc.rust-lang.org/cargo/reference/workspaces.html) is a _"set of packages that share the same Cargo.lock and output directory"_.
+A Rust Cargo "workspace" (see [here](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html) and [here](https://doc.rust-lang.org/cargo/reference/workspaces.html)) is a _"set of packages that share the same Cargo.lock and output directory"_.
 
 When using the workspace feature without a root package, i.e. your root `Cargo.toml` lacks a `[package]` section, this is known as a "virtual" workspace or manifest. When using a virtual workspace the package tooling is unable to find the configuration it needs in the root `Cargo.toml` and so you need to provide additional Ploutos settings to guide the package tooling to the right place.
 

--- a/docs/key_concepts_and_config.md
+++ b/docs/key_concepts_and_config.md
@@ -8,6 +8,7 @@
 - [Next dev version](#next-dev-version)
 - [Matrix rules](#matrix-rules)
 - [Caching and performance](#caching-and-performance)
+- [Cargo workspace support](#cargo-workspace-support)
 
 ## Stability promise
 
@@ -132,8 +133,19 @@ _**Known issue:** [Inconsistent Rust compiler version](https://github.com/NLnetL
 
 By default temporary and final produced artifacts are named under the assumption that no other workflow jobs exist that also upload artifacts and thus may cause artifact name conflicts.
 
-If necessary the `artifact_prefix` worjflow string input can be used to specify a prefix that will be added to every GitHub actions artifact uploaded by Ploutos.
+If necessary the `artifact_prefix` workflow string input can be used to specify a prefix that will be added to every GitHub actions artifact uploaded by Ploutos.
 
 ## Strict mode
 
 Some actions performed by Ploutos can result in warnings or errors that are potentially spurious, that is to say that just because Lintian or rpmlint or some other tool reports a problem does not mean to say that we should consider it fatal. For such cases Ploutos by default includes the output of the tools in the log, and in some cases raises warnings in the workflow log, but won't fail the workflow run. If needed by setting the `strict_mode` workflow input to `true` you can force Ploutos to be stricter in some cases than it would normally be.
+
+## Cargo workspace support
+
+A Rust Cargo "workspace" (see [here](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html) and [here](https://doc.rust-lang.org/cargo/reference/workspaces.html) is a _"set of packages that share the same Cargo.lock and output directory"_.
+
+When using the workspace feature without a root package, i.e. your root `Cargo.toml` lacks a `[package]` section, this is known as a "virtual" workspace or manifest. When using a virtual workspace the package tooling is unable to find the configuration it needs in the root `Cargo.toml` and so you need to provide additional Ploutos settings to guide the package tooling to the right place.
+
+Two string workflow inputs exist for this purpose:
+
+- `manifest_dir` - directs Ploutos to the directory containing the root `Cargo.toml`, if not actually in the root directory.
+- `workspace_package` - tells Ploutos which "workspace member" (child project directory) contains a `Cargo.toml` that includes the `[package]` section.


### PR DESCRIPTION
This breaking release contains the following changes:

- #67 including two new Ploutos settings: `manifest_dir` and `workspace_package` (see the updated docs for more information)
- Upgrade tools used to versions compatible with Cargo workspaces:
  - Upgrade [cargo-deb](https://crates.io/crates/cargo-deb) from 1.38.4 to 1.42.2.
  - Upgrade [cargo-generate-rpm](https://crates.io/crates/cargo-generate-rpm) from 0.8.0 to 0.10.1.
  - Upgrade [toml-cli](https://crates.io/crates/toml-cli) from 0.2.0 to 0.2.3.

Known issues:
- Now that `cargo-generate-rpm` supports setting the URL tag, instructing `rpmlint` to suppress error `no-url-tag` fails when the URL tag is actually set. Removing the suppression however causes existing projects that do not set the `package.homepage`, `package.repository` or `package.metadata.generate-rpm.url` to fail `rpmlint` validation because the URL tag is missing. To upgrade to this version of Ploutos you thus need to ensure a URL tag is set.
- [Lintian](https://wiki.debian.org/Lintian) is raising new error `manpage-not-compressed-with-max-compression` (and related warning `changelog-not-compressed-with-max-compression`). For now Ploutos suppresses the new error. This is possibly due to changes in the newer version of cargo-deb that we upgraded to but hasn't been investigated yet.
- There could be changes in the upgraded tool versions that result in breakage for users of Ploutos in ways that our test suite hasn't detected.

Successful test runs can be seen here:

- dev branch: https://github.com/NLnetLabs/ploutos-testing/actions/runs/4373390777
- main branch: https://github.com/NLnetLabs/ploutos-testing/actions/runs/4373476285
- release tag: https://github.com/NLnetLabs/ploutos-testing/actions/runs/4373564190
- Routinator: https://github.com/NLnetLabs/routinator/actions/runs/4375181007
- Krill: https://github.com/NLnetLabs/routinator/actions/runs/4375181007

Release checklist:

- [x] 1. Create a branch in the RELEASE repo, let's call this the RELEASE branch.
- [ ] 2. Change RPM_MACROS_URL in the workflow to point to the new RELEASE branch.
- [x] 3. Create a PR in the RELEASE repo for the RELEASE branch.
- [x] 4. Create a matching branch in the TEST repo, let's call this the TEST branch.
- [x] 5. Make the desired changes to the RELEASE branch.
- [x] 6. In the TEST branch modify `.github/workflows/pkg.yml` so that instead of referring to `pkg-rust.yml@vX` it refers to `pkg-rust.yml@<Git ref of HEAD commit on the TEST branch>` or `pkg-rust.yml@<test branch name>`.
- [x] 7. Create a PR in the `.gihub-testing` repository from the TEST branch to `main`, let's call this the TEST PR.
- [x] 8. Repeat steps 4 and 5 until the the `Packaging` workflow run in the TEST PR passes and behaves as desired.
- [x] 9. Merge the TEST PR to the `main` branch.
- [x] 10. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo against the `main` branch passes and behaves as desired. If not, repeat steps 4-9 until the new TEST PR passes and behaves as desired.
- [x] 11. Create a release tag in the TEST repo with the same release tag as will be used in the RELEASE repo, e.g. v1.2.3. _**Note:** Remember to respect semantic versioning, i.e. if the changes being made are not backward compatible you will need to bump the MAJOR version (in MAJOR.MINOR.PATCH) **and** any workflows that invoke the reusable workflow will need to be **manually edited** to refer to the new MAJOR version._
- [x] 12. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo passes against the newly created release tag passes and behaves as desired. If not, delete the release tag **in the TEST repo** and repeat steps 4-11 until the new TEST PR passes and behaves as desired.
- [ ] 13. Merge the RELEASE PR to the `main` branch.
- [ ] 14. Change RPM_MACROS_URL in the workflow to point to vX.Y.Z tag (if your release branch has a different name).
- [ ] 15. Create the new release vX.Y.Z tag in the RELEASE repo.
- [ ] 16. Update the vX tag in the RELEASE repo to point to the new vX.Y.Z tag ([howto](https://github.com/NLnetLabs/ploutos/blob/main/docs/develop/README.md#release-process)).
- [ ] 17. Edit `.github/workflows/pkg.yml` in the `main` branch of the TEST repo to refer again to `@vX`.
- [ ] 18. Verify that the `Packaging` action in the TEST repo against the `main` branch passes and works as desired.
- [ ] 19. (optional) If the MAJOR version was changed, update affected repositories that use the reusable workflow to use the new MAJOR version, including adjusting to any breaking changes introduced by the MAJOR version change.
