### PR TITLE
Fix CentOS 7 CGroupV1 incompatibility with LXD and newer host O/S versions

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1682,14 +1682,10 @@ jobs:
     # This wasn't needed with Ubuntu 20.04 but is needed with Ubuntu 22.04.
     - name: Fix firewall for LXD
       run: |
-        case ${OS_NAME} in
-          debian|ubuntu)
-            # Assume it is harmless to do this on older Ubuntu's and needed on newer Ubuntu's so don't bother trying
-            # to do complex O/S version based logic.
-            sudo iptables -I DOCKER-USER -i lxdbr0 -j ACCEPT
-            sudo iptables -I DOCKER-USER -o lxdbr0 -j ACCEPT
-            ;;
-        esac
+        # This issue seems to affect various newer O/S's and the fix seems to be harmless on older O/S's, so we don't
+        # bother trying to be clever about O/S version based logic but just do this for all hosts.
+        sudo iptables -I DOCKER-USER -i lxdbr0 -j ACCEPT
+        sudo iptables -I DOCKER-USER -o lxdbr0 -j ACCEPT
 
     - name: Add current user to LXD group
       run: |

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1577,7 +1577,7 @@ jobs:
     # I wouldn't expect this to be needed but since the cross job was made conditional we seem to need this.
     if: ${{ always() && needs.prepare.outputs.package_test_rules != '{}' }}
     needs: [pkg, prepare]
-    runs-on: ${{ inputs.runs_on }}
+    runs-on: ${{ (inputs.runs_on == 'ubuntu-latest' && matrix.image == 'centos:7') && 'ubuntu-20.04' || inputs.runs_on }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare.outputs.package_test_rules) }}
@@ -1699,7 +1699,7 @@ jobs:
       run: |
         # security.nesting=true is needed to avoid error "Failed to set up mount namespacing: Permission denied" in a
         # Debian 10 container.
-        sudo lxc launch ${LXC_IMAGE} -c security.nesting=true -c environment.DEBIAN_FRONTEND=noninteractive testcon --vm
+        sudo lxc launch ${LXC_IMAGE} -c security.nesting=true -c environment.DEBIAN_FRONTEND=noninteractive testcon
 
     # Run package update and install man and sudo support (missing in some LXC/LXD O/S images) but first wait for
     # cloud-init to finish otherwise the network isn't yet ready. Don't use cloud-init status --wait as that isn't

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1586,7 +1586,7 @@ jobs:
     # See:
     #   - https://github.com/NLnetLabs/ploutos/issues/50
     #   - https://github.com/actions/runner/issues/409#issuecomment-727565588
-    runs-on: ${{ (inputs.runs_on == 'ubuntu-22.04' && matrix.image == 'centos:7') && 'ubuntu-20.04' || inputs.runs_on }}
+    runs-on: ${{ (inputs.runs_on == 'ubuntu-22.04' && (matrix.image == 'centos:7' || matrix.image == 'ubuntu:xenial')) && 'ubuntu-20.04' || inputs.runs_on }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare.outputs.package_test_rules) }}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1699,7 +1699,7 @@ jobs:
       run: |
         # security.nesting=true is needed to avoid error "Failed to set up mount namespacing: Permission denied" in a
         # Debian 10 container.
-        sudo lxc launch ${LXC_IMAGE} -c security.nesting=true -c environment.DEBIAN_FRONTEND=noninteractive testcon
+        sudo lxc launch ${LXC_IMAGE} -c security.nesting=true -c environment.DEBIAN_FRONTEND=noninteractive testcon --vm
 
     # Run package update and install man and sudo support (missing in some LXC/LXD O/S images) but first wait for
     # cloud-init to finish otherwise the network isn't yet ready. Don't use cloud-init status --wait as that isn't

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -130,10 +130,10 @@ on:
   workflow_call:
     inputs:
       runs_on:
-        description: "An optional runner label to direct GitHub Actions to your desired (e.g. self-hosted) runner. Defaults to ubuntu-latest."
+        description: "An optional runner label to direct GitHub Actions to your desired (e.g. self-hosted) runner. Defaults to ubuntu-22.04."
         required: false
         type: string
-        default: 'ubuntu-latest'
+        default: 'ubuntu-22.04'
       cross_runs_on:
         description: "An optional runner label to direct GitHub Actions to your desired (e.g. self-hosted) runner from cross-compilation jobs. Defaults to the value of runs_on."
         required: false
@@ -1584,7 +1584,7 @@ jobs:
     # See:
     #   - https://github.com/NLnetLabs/ploutos/issues/50
     #   - https://github.com/actions/runner/issues/409#issuecomment-727565588
-    runs-on: ${{ (inputs.runs_on == 'ubuntu-latest' && matrix.image == 'centos:7') && 'ubuntu-20.04' || inputs.runs_on }}
+    runs-on: ${{ (inputs.runs_on == 'ubuntu-22.04' && matrix.image == 'centos:7') && 'ubuntu-20.04' || inputs.runs_on }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare.outputs.package_test_rules) }}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1683,7 +1683,7 @@ jobs:
     - name: Fix firewall for LXD
       run: |
         case ${OS_NAME} in
-          ubuntu)
+          debian|ubuntu)
             # Assume it is harmless to do this on older Ubuntu's and needed on newer Ubuntu's so don't bother trying
             # to do complex O/S version based logic.
             sudo iptables -I DOCKER-USER -i lxdbr0 -j ACCEPT

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1577,6 +1577,13 @@ jobs:
     # I wouldn't expect this to be needed but since the cross job was made conditional we seem to need this.
     if: ${{ always() && needs.prepare.outputs.package_test_rules != '{}' }}
     needs: [pkg, prepare]
+    # If runs_on is not overridden by the user, and we are about to test a package in a CentOS 7 LXC container, force
+    # the host O/S to be the older Ubuntu 20.04 as Ubuntu 22.04 upgraded from CGroupV1 to CGroupV2 which is incompatible
+    # with the CentOS 7 LXC image. Use a sort-of ternary if syntax that GitHub Actions supports in expressions to effect
+    # this dynamically per matrix invocation of the `pkg-test` job.
+    # See:
+    #   - https://github.com/NLnetLabs/ploutos/issues/50
+    #   - https://github.com/actions/runner/issues/409#issuecomment-727565588
     runs-on: ${{ (inputs.runs_on == 'ubuntu-latest' && matrix.image == 'centos:7') && 'ubuntu-20.04' || inputs.runs_on }}
     strategy:
       fail-fast: false
@@ -1675,8 +1682,14 @@ jobs:
     # This wasn't needed with Ubuntu 20.04 but is needed with Ubuntu 22.04.
     - name: Fix firewall for LXD
       run: |
-        sudo iptables -I DOCKER-USER -i lxdbr0 -j ACCEPT
-        sudo iptables -I DOCKER-USER -o lxdbr0 -j ACCEPT
+        case ${OS_NAME} in
+          ubuntu)
+            # Assume it is harmless to do this on older Ubuntu's and needed on newer Ubuntu's so don't bother trying
+            # to do complex O/S version based logic.
+            sudo iptables -I DOCKER-USER -i lxdbr0 -j ACCEPT
+            sudo iptables -I DOCKER-USER -o lxdbr0 -j ACCEPT
+            ;;
+        esac
 
     - name: Add current user to LXD group
       run: |

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -133,6 +133,8 @@ on:
         description: "An optional runner label to direct GitHub Actions to your desired (e.g. self-hosted) runner. Defaults to ubuntu-22.04."
         required: false
         type: string
+        # Don't use 'ubuntu-latest' as that could causes unexpected changes to occur when it is repointed at a newer
+        # O/S release.
         default: 'ubuntu-22.04'
       cross_runs_on:
         description: "An optional runner label to direct GitHub Actions to your desired (e.g. self-hosted) runner from cross-compilation jobs. Defaults to the value of runs_on."


### PR DESCRIPTION
This release contains the following changes:

- Use `ubuntu-22.04` as the GitHub host runner O/S version for all jobs instead of `ubuntu-latest` for reproducible behaviour (otherwise when `ubuntu-latest` is updated to point to a newer O/S release something could break) (part of #50).
- Work around error 'The image used by this instance requires a CGroupV1 host system' when testing packages on CentOS 7 or Ubuntu Xenial, using LXD on an `ubuntu-22.04` host, by forcing the use of an `ubuntu-20.04` host instead (part of #50). 

Successful test runs can be seen here:

- dev branch:[view](https://github.com/NLnetLabs/ploutos-testing/actions/runs/4850194475/jobs/8643013250)
- main branch: [view](https://github.com/NLnetLabs/ploutos-testing/actions/runs/4850383475)
- release tag: [view](https://github.com/NLnetLabs/ploutos-testing/actions/runs/4850446052)
- self-hosted runner test: [view](https://github.com/NLnetLabs/rotonda-runtime/actions/runs/4849704314)
- Routinator test: [view](https://github.com/NLnetLabs/routinator/actions/runs/4850560604)
- Krill test: [view](https://github.com/NLnetLabs/krill/actions/runs/4850558770)

Release checklist:

- [x] 1. Create a branch in the RELEASE repo, let's call this the RELEASE branch.
- [ ] 2. Change RPM_MACROS_URL in the workflow to point to the new RELEASE branch.
- [x] 3. Create a PR in the RELEASE repo for the RELEASE branch.
- [x] 4. Create a matching branch in the TEST repo, let's call this the TEST branch.
- [x] 5. Make the desired changes to the RELEASE branch.
- [x] 6. In the TEST branch modify `.github/workflows/pkg.yml` so that instead of referring to `pkg-rust.yml@vX` it refers to `pkg-rust.yml@<Git ref of HEAD commit on the TEST branch>` or `pkg-rust.yml@<test branch name>`.
- [x] 7. Create a PR in the `.gihub-testing` repository from the TEST branch to `main`, let's call this the TEST PR.
- [x] 8. Repeat steps 4 and 5 until the the `Packaging` workflow run in the TEST PR passes and behaves as desired.
- [x] 9. Merge the TEST PR to the `main` branch.
- [x] 10. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo against the `main` branch passes and behaves as desired. If not, repeat steps 4-9 until the new TEST PR passes and behaves as desired.
- [x] 11. Create a release tag in the TEST repo with the same release tag as will be used in the RELEASE repo, e.g. v1.2.3. _**Note:** Remember to respect semantic versioning, i.e. if the changes being made are not backward compatible you will need to bump the MAJOR version (in MAJOR.MINOR.PATCH) **and** any workflows that invoke the reusable workflow will need to be **manually edited** to refer to the new MAJOR version._
- [x] 12. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo passes against the newly created release tag passes and behaves as desired. If not, delete the release tag **in the TEST repo** and repeat steps 4-11 until the new TEST PR passes and behaves as desired.
- [ ] 13. Merge the RELEASE PR to the `main` branch.
- [ ] 14. Change RPM_MACROS_URL in the workflow to point to vX.Y.Z tag (if your release branch has a different name).
- [ ] 15. Create the new release vX.Y.Z tag in the RELEASE repo.
- [ ] 16. Update the vX tag in the RELEASE repo to point to the new vX.Y.Z tag ([howto](https://github.com/NLnetLabs/ploutos/blob/main/docs/develop/README.md#release-process)).
- [ ] 17. Edit `.github/workflows/pkg.yml` in the `main` branch of the TEST repo to refer again to `@vX`.
- [ ] 18. Verify that the `Packaging` action in the TEST repo against the `main` branch passes and works as desired.
- [ ] 19. (optional) If the MAJOR version was changed, update affected repositories that use the reusable workflow to use the new MAJOR version, including adjusting to any breaking changes introduced by the MAJOR version change.
