### PR TITLE
Release v7.2.1 (fixes #77, #78)

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1731,10 +1731,12 @@ jobs:
         done
 
         if [ $SUCCESS -eq 0 ]; then
-          ls -la /var/lib/
-          systemctl status cloud-init
-          journalctl -u cloud-init
-          journalctl
+          ls -la /var/lib/ || true
+          ls -lR /var/lib/cloud || true
+          systemctl status cloud-init || true
+          cloud-init status || true
+          journalctl -u cloud-init || true
+          journalctl || true
           exit 1
         fi
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -833,6 +833,7 @@ jobs:
 
     - name: Set vars
       id: setvars
+      # Disable default use of bash -x for easier to read output in the log
       shell: bash
       env:
         MATRIX_IMAGE: ${{ matrix.image }}
@@ -1636,6 +1637,7 @@ jobs:
     # that will be available in GH Action step definitions below.
     - name: Set vars
       id: setvars
+      # Disable default use of bash -x for easier to read output in the log
       shell: bash
       env:
         MATRIX_IMAGE: ${{ steps.verify.outputs.image }}
@@ -1717,7 +1719,6 @@ jobs:
     # supported on older O/S's like Ubuntu 16.04 and Debian 9. Use the sudo package provided configuration files
     # otherwise when using sudo we get an error that the root user isn't allowed to use sudo.
     - name: Prepare container
-      shell: bash
       run: |
         echo "Waiting for cloud-init.."
         SUCCESS=0

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1742,7 +1742,8 @@ jobs:
           sudo lxc exec testcon -- systemctl || true
           sudo lxc exec testcon -- journalctl -u cloud-init || true
           sudo lxc exec testcon -- journalctl || true
-          exit 1
+          # try and continue anyway...
+          echo "::warning::Unable to detect completion of cloud-init, subsequent steps may encounter unexpected failures"
         fi
 
         case ${OS_NAME} in

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -415,8 +415,8 @@ jobs:
           # Exclude debian:buster because the LXC image has problems starting cloud-init
           if [[ "${PACKAGE_TEST_RULES_PROCESSED_JSON}" != "{}" ]]; then
             CONTROL_JSON=$(echo ${PACKAGE_TEST_RULES_PROCESSED_JSON} | jq -c)
-            MODIFIED_JSON=$(echo ${PACKAGE_TEST_RULES_PROCESSED_JSON} | jq -c 'del(.image[]? | select(. == "debian:stretch")) | del(.include[]? | select(.image == "debian:stretch"))')
-            MODIFIED_JSON=$(echo ${MODIFIED_JSON} | jq -c 'del(.include[]? | select(.os == "debian:stretch"))')
+            MODIFIED_JSON=$(echo ${PACKAGE_TEST_RULES_PROCESSED_JSON} | jq -c 'del(.image[]? | select(. == "debian:buster")) | del(.include[]? | select(.image == "debian:buster"))')
+            MODIFIED_JSON=$(echo ${MODIFIED_JSON} | jq -c 'del(.include[]? | select(.os == "debian:buster"))')
             if [[ "${CONTROL_JSON}" != "${MODIFIED_JSON}" ]]; then
               echo "::warning::Removed debian:buster image from package_test_rules because the LXC image currently fails when running cloud-init"
               PACKAGE_TEST_RULES_PROCESSED_JSON="${MODIFIED_JSON}"

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1742,6 +1742,7 @@ jobs:
           sudo lxc exec testcon -- systemctl || true
           sudo lxc exec testcon -- journalctl -u cloud-init || true
           sudo lxc exec testcon -- journalctl || true
+          sudo lxc exec testcon -- cat /var/log/cloud*
           # try and continue anyway...
           echo "::warning::Unable to detect completion of cloud-init, subsequent steps may encounter unexpected failures"
         fi

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -418,7 +418,7 @@ jobs:
             MODIFIED_JSON=$(echo ${PACKAGE_TEST_RULES_PROCESSED_JSON} | jq -c 'del(.image[]? | select(. == "debian:buster")) | del(.include[]? | select(.image == "debian:buster"))')
             MODIFIED_JSON=$(echo ${MODIFIED_JSON} | jq -c 'del(.include[]? | select(.os == "debian:buster"))')
             if [[ "${CONTROL_JSON}" != "${MODIFIED_JSON}" ]]; then
-              echo "::warning::Removed debian:buster image from package_test_rules because the LXC image currently fails when running cloud-init"
+              echo "::warning::Removed debian:buster image from package_test_rules because the LXC image currently fails when running cloud-init. See: https://github.com/NLnetLabs/ploutos/issues/78"
               PACKAGE_TEST_RULES_PROCESSED_JSON="${MODIFIED_JSON}"
             fi
           fi

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1731,6 +1731,9 @@ jobs:
           fi
         done
 
+        # Log the cloud-init result file for diagnostic purposes
+        sudo lxc exec testcon -- cat /var/lib/cloud/data/result.json
+
         if [ $SUCCESS -eq 0 ]; then
           sudo lxc exec testcon -- ls -la /var/lib/ || true
           sudo lxc exec testcon -- ls -lR /var/lib/cloud || true

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1723,7 +1723,7 @@ jobs:
         echo "Waiting for cloud-init.."
         SUCCESS=0
         for i in $(seq 1 60); do
-          if sudo lxc exec testcon -- ls -la /var/lib/cloud/data/result.json || sudo lxc exec testcon -- cloud-init status | grep -F 'status: done'; then
+          if sudo lxc exec testcon -- ls -la /var/lib/cloud/data/result.json; then
             SUCCESS=1
             break
           else
@@ -1732,12 +1732,12 @@ jobs:
         done
 
         if [ $SUCCESS -eq 0 ]; then
-          ls -la /var/lib/ || true
-          ls -lR /var/lib/cloud || true
-          systemctl status cloud-init || true
-          cloud-init status || true
-          journalctl -u cloud-init || true
-          journalctl || true
+          sudo lxc exec testcon -- ls -la /var/lib/ || true
+          sudo lxc exec testcon -- ls -lR /var/lib/cloud || true
+          sudo lxc exec testcon -- systemctl status cloud-init || true
+          sudo lxc exec testcon -- cloud-init status || true
+          sudo lxc exec testcon -- journalctl -u cloud-init || true
+          sudo lxc exec testcon -- journalctl || true
           exit 1
         fi
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1745,7 +1745,7 @@ jobs:
           sudo lxc exec testcon -- systemctl || true
           sudo lxc exec testcon -- journalctl -u cloud-init || true
           sudo lxc exec testcon -- journalctl || true
-          sudo lxc exec testcon -- find /var/log/ -type f -iname '*cloud*' -print -exec cat {} /;
+          sudo lxc exec testcon -- find /var/log/ -type f -iname '*cloud*' -print -exec cat {} \;
           # try and continue anyway...
           echo "::warning::Unable to detect completion of cloud-init, subsequent steps may encounter unexpected failures. Check the logs just before this line."
         fi

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1742,7 +1742,7 @@ jobs:
           sudo lxc exec testcon -- systemctl || true
           sudo lxc exec testcon -- journalctl -u cloud-init || true
           sudo lxc exec testcon -- journalctl || true
-          sudo lxc exec testcon -- cat /var/log/cloud*
+          sudo lxc exec testcon -- find /var/log/ -type f -iname '*cloud*' -print -exec cat {} /;
           # try and continue anyway...
           echo "::warning::Unable to detect completion of cloud-init, subsequent steps may encounter unexpected failures. Check the logs just before this line."
         fi

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1734,8 +1734,12 @@ jobs:
         if [ $SUCCESS -eq 0 ]; then
           sudo lxc exec testcon -- ls -la /var/lib/ || true
           sudo lxc exec testcon -- ls -lR /var/lib/cloud || true
-          sudo lxc exec testcon -- systemctl status cloud-init || true
+          sudo lxc exec testcon -- ls -lR /usr/lib/systemd/system/ || true
+          sudo lxc exec testcon -- ls -lR /etc/cloud/ || true
+          sudo lxc exec testcon -- find /etc/cloud -type f -print -exec cat {} \; || true
           sudo lxc exec testcon -- cloud-init status || true
+          sudo lxc exec testcon -- systemctl status cloud-init || true
+          sudo lxc exec testcon -- systemctl || true
           sudo lxc exec testcon -- journalctl -u cloud-init || true
           sudo lxc exec testcon -- journalctl || true
           exit 1

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1723,7 +1723,7 @@ jobs:
         echo "Waiting for cloud-init.."
         SUCCESS=0
         for i in $(seq 1 60); do
-          if sudo lxc exec testcon -- ls -la /var/lib/cloud/data/result.json; then
+          if sudo lxc exec testcon -- ls -la /var/lib/cloud/data/result.json || sudo lxc exec testcon -- cloud-init status | grep -F 'status: done'; then
             SUCCESS=1
             break
           else

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1720,9 +1720,23 @@ jobs:
       shell: bash
       run: |
         echo "Waiting for cloud-init.."
-        while ! sudo lxc exec testcon -- ls -la /var/lib/cloud/data/result.json; do
+        SUCCESS=0
+        for i in $(seq 1 60); do
+          if sudo lxc exec testcon -- ls -la /var/lib/cloud/data/result.json; then
+            SUCCESS=1
+            break
+          else
           sleep 1s
+          fi
         done
+
+        if [ $SUCCESS -eq 0 ]; then
+          ls -la /var/lib/
+          systemctl status cloud-init
+          journalctl -u cloud-init
+          journalctl
+          exit 1
+        fi
 
         case ${OS_NAME} in
           debian|ubuntu)

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1744,7 +1744,7 @@ jobs:
           sudo lxc exec testcon -- journalctl || true
           sudo lxc exec testcon -- cat /var/log/cloud*
           # try and continue anyway...
-          echo "::warning::Unable to detect completion of cloud-init, subsequent steps may encounter unexpected failures"
+          echo "::warning::Unable to detect completion of cloud-init, subsequent steps may encounter unexpected failures. Check the logs just before this line."
         fi
 
         case ${OS_NAME} in

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1743,7 +1743,7 @@ jobs:
         done
 
         # Log the cloud-init result file for diagnostic purposes
-        sudo lxc exec testcon -- cat /var/lib/cloud/data/result.json
+        sudo lxc exec testcon -- cat /var/lib/cloud/data/result.json || true
 
         if [ $SUCCESS -eq 0 ]; then
           sudo lxc exec testcon -- ls -la /var/lib/ || true

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -412,6 +412,17 @@ jobs:
             fi
           fi
 
+          # Exclude debian:buster because the LXC image has problems starting cloud-init
+          if [[ "${PACKAGE_TEST_RULES_PROCESSED_JSON}" != "{}" ]]; then
+            CONTROL_JSON=$(echo ${PACKAGE_TEST_RULES_PROCESSED_JSON} | jq -c)
+            MODIFIED_JSON=$(echo ${PACKAGE_TEST_RULES_PROCESSED_JSON} | jq -c 'del(.image[]? | select(. == "debian:stretch")) | del(.include[]? | select(.image == "debian:stretch"))')
+            MODIFIED_JSON=$(echo ${MODIFIED_JSON} | jq -c 'del(.include[]? | select(.os == "debian:stretch"))')
+            if [[ "${CONTROL_JSON}" != "${MODIFIED_JSON}" ]]; then
+              echo "::warning::Removed debian:buster image from package_test_rules because the LXC image currently fails when running cloud-init"
+              PACKAGE_TEST_RULES_PROCESSED_JSON="${MODIFIED_JSON}"
+            fi
+          fi
+
           # Exclude non-x86_64 targets as we only run the tests on x86-64 GitHub runners
           if [[ "${PACKAGE_TEST_RULES_PROCESSED_JSON}" != "{}" ]]; then
             CONTROL_JSON=$(echo ${PACKAGE_TEST_RULES_PROCESSED_JSON} | jq -c)


### PR DESCRIPTION
This release contains the following changes:

- Loop for at most (approximately) 60 seconds testing for cloud-init to complete, then fail, instead of looping forever. (fixes #77)
- Exclude Debian Buster from testing until the cloud-init issue is resolved. (fixes #78)

Successful test runs can be seen here:

- dev branch: https://github.com/NLnetLabs/ploutos-testing/actions/runs/5524548203
- main branch: https://github.com/NLnetLabs/ploutos-testing/actions/runs/5529309396
- release tag: https://github.com/NLnetLabs/ploutos-testing/actions/runs/5529401751

Release checklist:

- [x] 1. Create a branch in the RELEASE repo, let's call this the RELEASE branch.
- [ ] 2. Change RPM_MACROS_URL in the workflow to point to the new RELEASE branch.
- [x] 3. Create a PR in the RELEASE repo for the RELEASE branch.
- [x] 4. Create a matching branch in the TEST repo, let's call this the TEST branch.
- [x] 5. Make the desired changes to the RELEASE branch.
- [x] 6. In the TEST branch modify `.github/workflows/pkg.yml` so that instead of referring to `pkg-rust.yml@vX` it refers to `pkg-rust.yml@<Git ref of HEAD commit on the TEST branch>` or `pkg-rust.yml@<test branch name>`.
- [x] 7. Create a PR in the `.gihub-testing` repository from the TEST branch to `main`, let's call this the TEST PR.
- [x] 8. Repeat steps 4 and 5 until the the `Packaging` workflow run in the TEST PR passes and behaves as desired.
- [x] 9. Merge the TEST PR to the `main` branch.
- [x] 10. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo against the `main` branch passes and behaves as desired. If not, repeat steps 4-9 until the new TEST PR passes and behaves as desired.
- [x] 11. Create a release tag in the TEST repo with the same release tag as will be used in the RELEASE repo, e.g. v1.2.3. _**Note:** Remember to respect semantic versioning, i.e. if the changes being made are not backward compatible you will need to bump the MAJOR version (in MAJOR.MINOR.PATCH) **and** any workflows that invoke the reusable workflow will need to be **manually edited** to refer to the new MAJOR version._
- [x] 12. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo passes against the newly created release tag passes and behaves as desired. If not, delete the release tag **in the TEST repo** and repeat steps 4-11 until the new TEST PR passes and behaves as desired.
- [x] 13. Merge the RELEASE PR to the `main` branch.
- [ ] 14. Change RPM_MACROS_URL in the workflow to point to vX.Y.Z tag (if your release branch has a different name).
- [ ] 15. Create the new release vX.Y.Z tag in the RELEASE repo.
- [ ] 16. Update the vX tag in the RELEASE repo to point to the new vX.Y.Z tag ([howto](https://github.com/NLnetLabs/ploutos/blob/main/docs/develop/README.md#release-process)).
- [ ] 17. Edit `.github/workflows/pkg.yml` in the `main` branch of the TEST repo to refer again to `@vX`.
- [ ] 18. Verify that the `Packaging` action in the TEST repo against the `main` branch passes and works as desired.
- [ ] 19. (optional) If the MAJOR version was changed, update affected repositories that use the reusable workflow to use the new MAJOR version, including adjusting to any breaking changes introduced by the MAJOR version change.
