### PR TITLE
Release v7.2.2

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -412,17 +412,6 @@ jobs:
             fi
           fi
 
-          # Exclude debian:buster because the LXC image has problems starting cloud-init
-          if [[ "${PACKAGE_TEST_RULES_PROCESSED_JSON}" != "{}" ]]; then
-            CONTROL_JSON=$(echo ${PACKAGE_TEST_RULES_PROCESSED_JSON} | jq -c)
-            MODIFIED_JSON=$(echo ${PACKAGE_TEST_RULES_PROCESSED_JSON} | jq -c 'del(.image[]? | select(. == "debian:buster")) | del(.include[]? | select(.image == "debian:buster"))')
-            MODIFIED_JSON=$(echo ${MODIFIED_JSON} | jq -c 'del(.include[]? | select(.os == "debian:buster"))')
-            if [[ "${CONTROL_JSON}" != "${MODIFIED_JSON}" ]]; then
-              echo "::warning::Removed debian:buster image from package_test_rules because the LXC image currently fails when running cloud-init. See: https://github.com/NLnetLabs/ploutos/issues/78"
-              PACKAGE_TEST_RULES_PROCESSED_JSON="${MODIFIED_JSON}"
-            fi
-          fi
-
           # Exclude non-x86_64 targets as we only run the tests on x86-64 GitHub runners
           if [[ "${PACKAGE_TEST_RULES_PROCESSED_JSON}" != "{}" ]]; then
             CONTROL_JSON=$(echo ${PACKAGE_TEST_RULES_PROCESSED_JSON} | jq -c)


### PR DESCRIPTION
This release contains the following changes:

- Revert the Buster test exclusion now that the LXC project appears to have fixed their broken images.

Successful test runs can be seen here:

- dev branch: https://github.com/NLnetLabs/ploutos-testing/actions/runs/5541981852
- main branch: https://github.com/NLnetLabs/ploutos-testing/actions/runs/5542123249 (IN PROGRESS)
- release tag: TODO

Release checklist:

- [x] 1. Create a branch in the RELEASE repo, let's call this the RELEASE branch.
- [ ] 2. Change RPM_MACROS_URL in the workflow to point to the new RELEASE branch.
- [x] 3. Create a PR in the RELEASE repo for the RELEASE branch.
- [x] 4. Create a matching branch in the TEST repo, let's call this the TEST branch.
- [x] 5. Make the desired changes to the RELEASE branch.
- [x] 6. In the TEST branch modify `.github/workflows/pkg.yml` so that instead of referring to `pkg-rust.yml@vX` it refers to `pkg-rust.yml@<Git ref of HEAD commit on the TEST branch>` or `pkg-rust.yml@<test branch name>`.
- [x] 7. Create a PR in the `.gihub-testing` repository from the TEST branch to `main`, let's call this the TEST PR.
- [x] 8. Repeat steps 4 and 5 until the the `Packaging` workflow run in the TEST PR passes and behaves as desired.
- [x] 9. Merge the TEST PR to the `main` branch.
- [x] 10. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo against the `main` branch passes and behaves as desired. If not, repeat steps 4-9 until the new TEST PR passes and behaves as desired.
- [x] 11. Create a release tag in the TEST repo with the same release tag as will be used in the RELEASE repo, e.g. v1.2.3. _**Note:** Remember to respect semantic versioning, i.e. if the changes being made are not backward compatible you will need to bump the MAJOR version (in MAJOR.MINOR.PATCH) **and** any workflows that invoke the reusable workflow will need to be **manually edited** to refer to the new MAJOR version._
- [x] 12. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo passes against the newly created release tag passes and behaves as desired. If not, delete the release tag **in the TEST repo** and repeat steps 4-11 until the new TEST PR passes and behaves as desired.
- [ ] 13. Merge the RELEASE PR to the `main` branch.
- [ ] 14. Change RPM_MACROS_URL in the workflow to point to vX.Y.Z tag (if your release branch has a different name).
- [ ] 15. Create the new release vX.Y.Z tag in the RELEASE repo.
- [ ] 16. Update the vX tag in the RELEASE repo to point to the new vX.Y.Z tag ([howto](https://github.com/NLnetLabs/ploutos/blob/main/docs/develop/README.md#release-process)).
- [ ] 17. Edit `.github/workflows/pkg.yml` in the `main` branch of the TEST repo to refer again to `@vX`.
- [ ] 18. Verify that the `Packaging` action in the TEST repo against the `main` branch passes and works as desired.
- [ ] 19. (optional) If the MAJOR version was changed, update affected repositories that use the reusable workflow to use the new MAJOR version, including adjusting to any breaking changes introduced by the MAJOR version change.
