### PR TITLE
Expose optional `extra_cargo_deb_args` arg for package_build_rules

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1061,6 +1061,7 @@ jobs:
       env:
         MATRIX_PKG: ${{ steps.verify.outputs.pkg }}
         EXTRA_BUILD_ARGS: ${{ matrix.extra_build_args }}
+        EXTRA_CARGO_DEB_ARGS: ${{ matrix.extra_cargo_deb_args }}
         CROSS_TARGET: ${{ matrix.target }}
       run: |
         # Debian
@@ -1124,7 +1125,6 @@ jobs:
                      ${{ needs.prepare.outputs.cargo_package_toml_path }}
             fi
 
-            EXTRA_CARGO_DEB_ARGS=
             VARIANT="${OS_NAME}-${OS_REL}"
 
             # Older O/S releases come with an older version of systemd which understands far fewer keys in the systemd
@@ -1138,7 +1138,7 @@ jobs:
             # manually. The project being packaged can either define a cross-target specific `cargo-deb` profile, or a 
             # "minimal" profile suitable for cross-compiled targets.
             if [[ "${CROSS_TARGET}" != "x86_64" ]]; then
-              EXTRA_CARGO_DEB_ARGS="--no-build --no-strip --target ${CROSS_TARGET} --output ${TARGET_DIR}/debian"
+              EXTRA_CARGO_DEB_ARGS="--no-build --no-strip --target ${CROSS_TARGET} --output ${TARGET_DIR}/debian ${EXTRA_CARGO_DEB_ARGS}"
               MINIMAL_VARIANT="minimal-cross"
               VARIANT="${OS_NAME}-${OS_REL}-${CROSS_TARGET}"
             fi

--- a/docs/os_packaging.md
+++ b/docs/os_packaging.md
@@ -189,7 +189,8 @@ A rules [matrix](./key_concepts_and_config.md#matrix-rules) with the following k
 | `image` | Yes | Specifies the Docker image used by GitHub Actions to run the job in which your application will be built (when not cross-compiled) and packaged. The package type to build is implied by `<os_name>`, e.g. DEBs for Ubuntu and Debian, RPMs for CentOS Has the form `<os_name>:<os_rel>` (e.g. `ubuntu:jammy`, `debian:buster`, `centos:7`, etc). Also see `os` below.  |
 | `target` | Yes | Should be `x86_64` If `x86_64` the Rust application will be compiled using `cargo-deb` (for DEB) or `cargo build` (for RPM) and stripped. Otherwise it will be used to determine the cross-compiled binary GitHub Actions artifact to compile and download. |
 | `os` | No | Overrides the value of `image` when determining `os_name` and `os_rel`. |
-| `extra_build_args` | No | A space separated set of additional command line arguments to pass to `cargo-deb`/`cargo build`. |
+| `extra_build_args` | No | A space separated set of additional command line arguments to pass to `cargo build` (possibly via `cargo-deb`). |
+| `extra_cargo_deb_args` | No | A space separated set of additional command line arguments to pass to `cargo-deb` |
 | `deb_extra_lintian_args` | No | A space separated set of additional command line arguments to pass to the Debian Lintian package linting tool. Useful to suppress errors you wish to ignore or to supress warnings when `strict_mode` is set to `true`. |
 | `rpm_systemd_service_unit_file` | No | Relative path to the systemd file, or files (if it ends with `*`) to inclde in an RPM package. See below for more info. |
 | `rpm_rpmlint_check_filters` | No | A space separated set of additional rpmlint checks to filter out. See https://fedoraproject.org/wiki/Common_Rpmlint_issues for some example check names, e.g. `no-documentation`. |


### PR DESCRIPTION
This PR contains the following changes:

- Expose optional `extra_cargo_deb_args` argument

Successful test runs can be seen here:

- main branch: [fork](https://github.com/NLnetLabs/archive-keyring/actions/runs/7488896183)