### PR TITLE
Revert "Bump actions/cache from 3 to 4"

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -723,7 +723,7 @@ jobs:
     - name: Fetch cargo cross if available
       if: ${{ steps.skip.skip != 'true' }}
       id: cache-cargo-cross
-      uses: actions/cache@v4
+      uses: actions/cache@v3
       with:
         path: |
           ${{ steps.rust.outputs.bin_dir }}/cross
@@ -739,7 +739,7 @@ jobs:
 
     - name: Force cache save
       if: ${{ steps.skip.skip != 'true' && steps.install-cargo-cross.outputs.installed == 'true' }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v3
       with:
         path: |
           ${{ steps.rust.outputs.bin_dir }}/cross
@@ -950,7 +950,7 @@ jobs:
     # Speed up Rust builds by caching unchanged built dependencies.
     # See: https://github.com/actions/cache/blob/master/examples.md#rust---cargo
     - name: Fetch .cargo from cache
-      uses: actions/cache@v4
+      uses: actions/cache@v3
       with:
         path: |
           ~/.cargo/registry
@@ -961,21 +961,21 @@ jobs:
     # the tool that we are using.
     - name: Fetch cargo-deb from cache
       id: cache-cargo-deb
-      uses: actions/cache@v4
+      uses: actions/cache@v3
       with:
         path: ${{ steps.rust.outputs.bin_dir }}/cargo-deb
         key: ${{ matrix.image }}-cargo-deb-${{ env.CARGO_DEB_VER }}-${{ endsWith(matrix.image, 'xenial')}}
 
     - name: Fetch cargo-generate-rpm from cache
       id: cache-cargo-generate-rpm
-      uses: actions/cache@v4
+      uses: actions/cache@v3
       with:
         path: ${{ steps.rust.outputs.bin_dir }}/cargo-generate-rpm
         key: ${{ matrix.image }}-cargo-generate-rpm-${{ env.CARGO_GENERATE_RPM_VER }}
 
     - name: Fetch toml-cli from cache
       id: cache-toml-cli
-      uses: actions/cache@v4
+      uses: actions/cache@v3
       with:
         path: ${{ steps.rust.outputs.bin_dir }}/toml
         key: ${{ matrix.image }}-toml-cli-${{ env.TOML_CLI_VER }}
@@ -1004,7 +1004,7 @@ jobs:
 
     - name: Force cache save
       if: ${{ steps.install-cargo-deb.outputs.installed == 'true' }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v3
       with:
         path: ${{ steps.rust.outputs.bin_dir }}/cargo-deb
         key: ${{ matrix.image }}-cargo-deb-${{ env.CARGO_DEB_VER }}-${{ endsWith(matrix.image, 'xenial')}}
@@ -1022,7 +1022,7 @@ jobs:
 
     - name: Force cache save
       if: ${{ steps.install-cargo-generate-rpm.outputs.installed == 'true' }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v3
       with:
         path: ${{ steps.rust.outputs.bin_dir }}/cargo-generate-rpm
         key: ${{ matrix.image }}-cargo-generate-rpm-${{ env.CARGO_GENERATE_RPM_VER }}
@@ -1036,7 +1036,7 @@ jobs:
 
     - name: Force cache save
       if: ${{ steps.install-toml-cli.outputs.installed == 'true' }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v3
       with:
         path: ${{ steps.rust.outputs.bin_dir }}/toml
         key: ${{ matrix.image }}-toml-cli-${{ env.TOML_CLI_VER }}


### PR DESCRIPTION
Reverts NLnetLabs/ploutos#101 as it doesn't work on older targets such as Ubuntu Bionic and Debian Stretch due to outdated GLIBC, e.g.:

On Ubuntu Bionic:
```
Run actions/cache@v4
/usr/bin/docker exec  5157cf71f42fd7233b87eadd3e76b7e58b134295da8929e7f067001c71afb639 sh -c "cat /etc/*release | grep ^ID"
/__e/node20/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
```

On Debian Stretch:
```
Run actions/cache@v4
/usr/bin/docker exec  9c558e49fb5dc7ae8356077f61fe309be8a73b648e4daba5830fb06c8c333d6f sh -c "cat /etc/*release | grep ^ID"
/__e/node20/bin/node: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.27' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.25' not found (required by /__e/node20/bin/node)
```