### PR TITLE
Adjust action to use v4-compatible version of upload/download artifact

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -822,7 +822,7 @@ jobs:
     # `tmp-` which will be ignored by packages.nlnetlabs.nl scripts.
     - name: Upload built binaries
       if: ${{ steps.skip.skip != 'true' }}
-      uses: Koenvh1/upload-artifact@main
+      uses: NLnetLabs/upload-artifact@main
       with:
         name: ${{ inputs.artifact_prefix }}tmp-cross-binaries-${{ matrix.target }}
         path: bins.tar
@@ -1096,7 +1096,7 @@ jobs:
 
     - name: Download cross-compiled binaries
       if: ${{ matrix.target != 'x86_64' }}
-      uses: Koenvh1/download-artifact@main
+      uses: NLnetLabs/download-artifact@main
       with:
         name: ${{ inputs.artifact_prefix }}tmp-cross-binaries-${{ matrix.target }}
         path: .
@@ -1616,7 +1616,7 @@ jobs:
     # but only to users logged in to GH with sufficient rights in this project. The uploaded artifact is also downloaded
     # by the next job (see below) to sanity check that it can be installed and results in a working Krill installation.
     - name: Upload package
-      uses: Koenvh1/upload-artifact@main
+      uses: NLnetLabs/upload-artifact@main
       with:
         name: ${{ inputs.artifact_prefix }}${{ steps.verify.outputs.pkg }}_${{ env.OS_NAME }}_${{ env.OS_REL }}_${{ matrix.target }}
         path: |
@@ -2069,7 +2069,7 @@ jobs:
 
       - name: Download cross-compiled binaries
         if: ${{ steps.verify.outputs.mode == 'copy' }}
-        uses: Koenvh1/download-artifact@main
+        uses: NLnetLabs/download-artifact@main
         with:
           name: ${{ inputs.artifact_prefix }}tmp-cross-binaries-${{ matrix.target }}
           # The file downloaded to dockerbin/xxx will be used by the Dockerfile
@@ -2135,7 +2135,7 @@ jobs:
 
       # Upload the Docker image as a GitHub Actions artifact, handy when not publishing or investigating a problem
       - name: Upload built image to GitHub Actions
-        uses: Koenvh1/upload-artifact@main
+        uses: NLnetLabs/upload-artifact@main
         with:
           name: ${{ inputs.artifact_prefix }}tmp-docker-image-${{ matrix.shortname }}
           path: /tmp/docker-${{ matrix.shortname }}-img.tar

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -822,7 +822,7 @@ jobs:
     # `tmp-` which will be ignored by packages.nlnetlabs.nl scripts.
     - name: Upload built binaries
       if: ${{ steps.skip.skip != 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: Koenvh1/upload-artifact@main
       with:
         name: ${{ inputs.artifact_prefix }}tmp-cross-binaries-${{ matrix.target }}
         path: bins.tar
@@ -1616,7 +1616,7 @@ jobs:
     # but only to users logged in to GH with sufficient rights in this project. The uploaded artifact is also downloaded
     # by the next job (see below) to sanity check that it can be installed and results in a working Krill installation.
     - name: Upload package
-      uses: actions/upload-artifact@v4
+      uses: Koenvh1/upload-artifact@main
       with:
         name: ${{ inputs.artifact_prefix }}${{ steps.verify.outputs.pkg }}_${{ env.OS_NAME }}_${{ env.OS_REL }}_${{ matrix.target }}
         path: |
@@ -2135,7 +2135,7 @@ jobs:
 
       # Upload the Docker image as a GitHub Actions artifact, handy when not publishing or investigating a problem
       - name: Upload built image to GitHub Actions
-        uses: actions/upload-artifact@v4
+        uses: Koenvh1/upload-artifact@main
         with:
           name: ${{ inputs.artifact_prefix }}tmp-docker-image-${{ matrix.shortname }}
           path: /tmp/docker-${{ matrix.shortname }}-img.tar

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -822,10 +822,11 @@ jobs:
     # `tmp-` which will be ignored by packages.nlnetlabs.nl scripts.
     - name: Upload built binaries
       if: ${{ steps.skip.skip != 'true' }}
-      uses: umutozd/upload-artifact@fixing-unrecognized-if-no-files-found-input-error
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifact_prefix }}tmp-cross-binaries-${{ matrix.target }}
         path: bins.tar
+        if-no-files-found: warn
 
   # -------------------------------------------------------------------------------------------------------------------
   # Job: 'pkg'
@@ -1095,7 +1096,7 @@ jobs:
 
     - name: Download cross-compiled binaries
       if: ${{ matrix.target != 'x86_64' }}
-      uses: ximon18/download-artifact@v3
+      uses: Koenvh1/download-artifact@main
       with:
         name: ${{ inputs.artifact_prefix }}tmp-cross-binaries-${{ matrix.target }}
         path: .
@@ -1615,12 +1616,13 @@ jobs:
     # but only to users logged in to GH with sufficient rights in this project. The uploaded artifact is also downloaded
     # by the next job (see below) to sanity check that it can be installed and results in a working Krill installation.
     - name: Upload package
-      uses: umutozd/upload-artifact@fixing-unrecognized-if-no-files-found-input-error
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifact_prefix }}${{ steps.verify.outputs.pkg }}_${{ env.OS_NAME }}_${{ env.OS_REL }}_${{ matrix.target }}
         path: |
           ${{ steps.create.outputs.target_dir }}/debian/*.deb
           ${{ steps.create.outputs.target_dir }}/generate-rpm/*.rpm
+        if-no-files-found: warn
 
   # -------------------------------------------------------------------------------------------------------------------
   # Job: 'pkg-test'
@@ -1731,7 +1733,7 @@ jobs:
         fi
 
     - name: Download package
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.artifact_prefix }}${{ steps.verify.outputs.pkg }}_${{ env.OS_NAME }}_${{ env.OS_REL }}_${{ matrix.target }}
 
@@ -2067,7 +2069,7 @@ jobs:
 
       - name: Download cross-compiled binaries
         if: ${{ steps.verify.outputs.mode == 'copy' }}
-        uses: ximon18/download-artifact@v3
+        uses: Koenvh1/download-artifact@main
         with:
           name: ${{ inputs.artifact_prefix }}tmp-cross-binaries-${{ matrix.target }}
           # The file downloaded to dockerbin/xxx will be used by the Dockerfile
@@ -2133,10 +2135,11 @@ jobs:
 
       # Upload the Docker image as a GitHub Actions artifact, handy when not publishing or investigating a problem
       - name: Upload built image to GitHub Actions
-        uses: umutozd/upload-artifact@fixing-unrecognized-if-no-files-found-input-error
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.artifact_prefix }}tmp-docker-image-${{ matrix.shortname }}
           path: /tmp/docker-${{ matrix.shortname }}-img.tar
+          if-no-files-found: warn
 
       - name: Publish image to Docker Hub
         id: publish


### PR DESCRIPTION
This release contains the following changes:

- Update download-artifact and upload-artifact to v4-compatible due to GitHub changes:
> Artifact actions v3 will be deprecated by December 5, 2024. You are receiving this email because you have GitHub Actions workflows using v3 of actions/upload-artifact or actions/download-artifact. After this date using v3 of these actions will result in a workflow failure. Artifacts within their retention period will remain accessible from the UI or REST API regardless of the version used to upload.
- Re-add the waiting mechanism from https://github.com/ximon18/download-artifact for v4 in https://github.com/Koenvh1/download-artifact
- Replace upload-artifact@v4 with https://github.com/Koenvh1/upload-artifact to use Node 16 for older distributions 

Successful test runs can be seen here:

- dev branch: https://github.com/NLnetLabs/ploutos-testing/actions/runs/11954910761
- main branch: https://github.com/NLnetLabs/ploutos-testing/actions/runs/11955010231
- release tag: https://github.com/NLnetLabs/ploutos-testing/actions/runs/11955482049

Release checklist:

- [x] 1. Create a branch in the RELEASE repo, let's call this the RELEASE branch.
- [x] 2. Change RPM_MACROS_URL in the workflow to point to the new RELEASE branch.
- [x] 3. Create a PR in the RELEASE repo for the RELEASE branch.
- [x] 4. Create a matching branch in the TEST repo, let's call this the TEST branch.
- [x] 5. Make the desired changes to the RELEASE branch.
- [x] 6. In the TEST branch modify `.github/workflows/pkg.yml` so that instead of referring to `pkg-rust.yml@vX` it refers to `pkg-rust.yml@<Git ref of HEAD commit on the TEST branch>` or `pkg-rust.yml@<test branch name>`.
- [x] 7. Create a PR in the `ploutos-testing` repository from the TEST branch to `main`, let's call this the TEST PR.
- [x] 8. Repeat step 5 until the the `Packaging` workflow run in the TEST PR passes and behaves as desired.
- [x] 9. Merge the TEST PR to the `main` branch.
- [x] 10. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo against the `main` branch passes and behaves as desired. If not, repeat steps 4-9 until the new TEST PR passes and behaves as desired.
- [x] 11. Create a release tag in the TEST repo with the same release tag as will be used in the RELEASE repo, e.g. v1.2.3. _**Note:** Remember to respect semantic versioning, i.e. if the changes being made are not backward compatible you will need to bump the MAJOR version (in MAJOR.MINOR.PATCH) **and** any workflows that invoke the reusable workflow will need to be **manually edited** to refer to the new MAJOR version._
- [x] 12. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo passes against the newly created release tag passes and behaves as desired. If not, delete the release tag **in the TEST repo** and repeat steps 4-11 until the new TEST PR passes and behaves as desired.
- [x] 13. Merge the RELEASE PR to the `main` branch.
- [x] 14. Change RPM_MACROS_URL in the workflow to point to vX.Y.Z tag (if your release branch has a different name).
- [x] 15. Create the new release vX.Y.Z tag in the RELEASE repo.
- [x] 16. Update the vX tag in the RELEASE repo to point to the new vX.Y.Z tag ([howto](https://github.com/NLnetLabs/ploutos/blob/main/docs/develop/README.md#release-process)).
- [x] 17. Edit `.github/workflows/pkg.yml` in the `main` branch of the TEST repo to refer again to `@vX`.
- [x] 18. Verify that the `Packaging` action in the TEST repo against the `main` branch passes and works as desired.
- [x] 19. (optional) If the MAJOR version was changed, update affected repositories that use the reusable workflow to use the new MAJOR version, including adjusting to any breaking changes introduced by the MAJOR version change.
