### PR TITLE
Remove support for Ubuntu 18.04 LTS (Bionic Beaver) and Debian 9 (Stretch)

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -871,7 +871,7 @@ jobs:
       # actions use node v20 which doesn't work on containers with older GLIBC such as ubuntu:bionic or centos:7
       #uses: actions/checkout@v3 
       run: |
-        if type apt-get &/dev/null; then
+        if type apt-get &>/dev/null; then
           apt-get update
           apt-get install -y git
         elif type yum &>/dev/null; then

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -879,7 +879,7 @@ jobs:
           yum update -y # See: https://github.com/NLnetLabs/ploutos/issues/90
           yum install -y git
         fi
-        git clone https://${{ github.server_url }}/${{ github.repository }} --branch ${{ github.ref_name }} --single-branch $GITHUB_WORKSPACE
+        git clone ${{ github.server_url }}/${{ github.repository }} --branch ${{ github.ref_name }} --single-branch $GITHUB_WORKSPACE
 
     - name: Print matrix
       # Disable default use of bash -x for easier to read output in the log

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -851,8 +851,35 @@ jobs:
       CARGO_GENERATE_RPM_VER: 0.10.2
       TOML_CLI_VER: 0.2.3
     steps:
+    # Allow CentOS 8 to continue working now that it is EOL
+    # See: https://stackoverflow.com/a/70930049
+    - name: CentOS 8 EOL workaround
+      if: ${{ matrix.image == 'centos:8' }}
+      run: |
+        sed -i -e 's|mirrorlist=|#mirrorlist=|g' -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+    
+    # See: https://github.com/NLnetLabs/ploutos
+    # See: https://lists.debian.org/debian-devel-announce/2023/03/msg00006.html
+    # See: https://unix.stackexchange.com/a/743865
+    - name: Debian Stretch workaround
+      if: ${{ matrix.image == 'debian:stretch' }}
+      run: |
+        echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list
+        echo "deb http://archive.debian.org/debian-security stretch/updates main" >> /etc/apt/sources.list
+
     - name: Checkout repository
-      uses: actions/checkout@v3 # v4 doesn't work on containers with older GLIBC such as ubuntu:bionic or centos:7
+      # actions use node v20 which doesn't work on containers with older GLIBC such as ubuntu:bionic or centos:7
+      #uses: actions/checkout@v3 
+      run: |
+        if which apt >/dev/null; then
+          apt-get update
+          apt-get install -y git
+        elif which yum >/dev/null; then
+          #sed -i -e 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf || true
+          yum update -y # See: https://github.com/NLnetLabs/ploutos/issues/90
+          yum install -y git
+        fi
+        git clone https://${{ github.server_url }}/${{ github.repository }} --branch ${{ github.ref_name }} --single-branch $GITHUB_WORKSPACE
 
     - name: Print matrix
       # Disable default use of bash -x for easier to read output in the log
@@ -926,29 +953,12 @@ jobs:
         echo "OS_NAME=${IMAGE%:*}" >> $GITHUB_ENV
         echo "OS_REL=${IMAGE#*:}" >> $GITHUB_ENV
 
-    # Allow CentOS 8 to continue working now that it is EOL
-    # See: https://stackoverflow.com/a/70930049
-    - name: CentOS 8 EOL workaround
-      if: ${{ matrix.image == 'centos:8' }}
-      run: |
-        sed -i -e 's|mirrorlist=|#mirrorlist=|g' -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
-    
-    # See: https://github.com/NLnetLabs/ploutos
-    # See: https://lists.debian.org/debian-devel-announce/2023/03/msg00006.html
-    # See: https://unix.stackexchange.com/a/743865
-    - name: Debian Stretch workaround
-      if: ${{ matrix.image == 'debian:stretch' }}
-      run: |
-        echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list
-        echo "deb http://archive.debian.org/debian-security stretch/updates main" >> /etc/apt/sources.list
-
     # Install Rust the hard way rather than using a GH Action because the action doesn't work inside a Docker container.
     - name: Install Rust
       id: rust
       run: |
         case ${OS_NAME} in
           debian|ubuntu)
-            apt-get update
             apt-get install -y curl
             ;;
         esac
@@ -978,8 +988,6 @@ jobs:
             apt-get install -y binutils gcc dpkg-dev jq lintian pkg-config ${{ inputs.deb_extra_build_packages }}
             ;;
           centos|rockylinux)
-            #sed -i -e 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf || true
-            yum update -y # See: https://github.com/NLnetLabs/ploutos/issues/90
             yum install epel-release -y
             yum install -y findutils gcc jq ${{ inputs.rpm_extra_build_packages }}
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -871,10 +871,10 @@ jobs:
       # actions use node v20 which doesn't work on containers with older GLIBC such as ubuntu:bionic or centos:7
       #uses: actions/checkout@v3 
       run: |
-        if which apt >/dev/null; then
+        if type apt-get &/dev/null; then
           apt-get update
           apt-get install -y git
-        elif which yum >/dev/null; then
+        elif type yum &>/dev/null; then
           #sed -i -e 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf || true
           yum update -y # See: https://github.com/NLnetLabs/ploutos/issues/90
           yum install -y git

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -399,6 +399,17 @@ jobs:
             fi
           fi
 
+          # Exclude ubuntu:bionic as its GLIBC is too old to support Node 20 now required to use GitHub Actions
+          if [[ "${PACKAGE_BUILD_RULES_PROCESSED_JSON}" != "{}" ]]; then
+            CONTROL_JSON=$(echo ${PACKAGE_BUILD_RULES_PROCESSED_JSON} | jq -c)
+            MODIFIED_JSON=$(echo ${PACKAGE_BUILD_RULES_PROCESSED_JSON} | jq -c 'del(.image[]? | select(. == "ubuntu:bionic")) | del(.include[]? | select(.image == "ubuntu:bionic"))')
+            MODIFIED_JSON=$(echo ${MODIFIED_JSON} | jq -c 'del(.include[]? | select(.os == "ubuntu:bionic"))')
+            if [[ "${CONTROL_JSON}" != "${MODIFIED_JSON}" ]]; then
+              echo "::warning::Removed ubuntu:bionic image from package_build_rules because its GLIBC is too old to support Node 20 required by GitHub Actions"
+              PACKAGE_BUILD_RULES_PROCESSED_JSON="${MODIFIED_JSON}"
+            fi
+          fi
+
           echo "package_build_rules<<END_OF_PACKAGE_BUILD_RULES" >> $GITHUB_OUTPUT
           echo ${PACKAGE_BUILD_RULES_PROCESSED_JSON} | jq >> $GITHUB_OUTPUT
           echo 'END_OF_PACKAGE_BUILD_RULES' >> $GITHUB_OUTPUT
@@ -851,35 +862,8 @@ jobs:
       CARGO_GENERATE_RPM_VER: 0.10.2
       TOML_CLI_VER: 0.2.3
     steps:
-    # Allow CentOS 8 to continue working now that it is EOL
-    # See: https://stackoverflow.com/a/70930049
-    - name: CentOS 8 EOL workaround
-      if: ${{ matrix.image == 'centos:8' }}
-      run: |
-        sed -i -e 's|mirrorlist=|#mirrorlist=|g' -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
-    
-    # See: https://github.com/NLnetLabs/ploutos
-    # See: https://lists.debian.org/debian-devel-announce/2023/03/msg00006.html
-    # See: https://unix.stackexchange.com/a/743865
-    - name: Debian Stretch workaround
-      if: ${{ matrix.image == 'debian:stretch' }}
-      run: |
-        echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list
-        echo "deb http://archive.debian.org/debian-security stretch/updates main" >> /etc/apt/sources.list
-
     - name: Checkout repository
-      # actions use node v20 which doesn't work on containers with older GLIBC such as ubuntu:bionic or centos:7
-      #uses: actions/checkout@v3 
-      run: |
-        if type apt-get &>/dev/null; then
-          apt-get update
-          apt-get install -y git
-        elif type yum &>/dev/null; then
-          #sed -i -e 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf || true
-          yum update -y # See: https://github.com/NLnetLabs/ploutos/issues/90
-          yum install -y git
-        fi
-        git clone ${{ github.server_url }}/${{ github.repository }} --branch ${{ github.ref_name }} --single-branch $GITHUB_WORKSPACE
+      uses: actions/checkout@v3 # v4 doesn't work on containers with older GLIBC such as ubuntu:bionic or centos:7
 
     - name: Print matrix
       # Disable default use of bash -x for easier to read output in the log
@@ -953,12 +937,29 @@ jobs:
         echo "OS_NAME=${IMAGE%:*}" >> $GITHUB_ENV
         echo "OS_REL=${IMAGE#*:}" >> $GITHUB_ENV
 
+    # Allow CentOS 8 to continue working now that it is EOL
+    # See: https://stackoverflow.com/a/70930049
+    - name: CentOS 8 EOL workaround
+      if: ${{ matrix.image == 'centos:8' }}
+      run: |
+        sed -i -e 's|mirrorlist=|#mirrorlist=|g' -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+    
+    # See: https://github.com/NLnetLabs/ploutos
+    # See: https://lists.debian.org/debian-devel-announce/2023/03/msg00006.html
+    # See: https://unix.stackexchange.com/a/743865
+    - name: Debian Stretch workaround
+      if: ${{ matrix.image == 'debian:stretch' }}
+      run: |
+        echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list
+        echo "deb http://archive.debian.org/debian-security stretch/updates main" >> /etc/apt/sources.list
+
     # Install Rust the hard way rather than using a GH Action because the action doesn't work inside a Docker container.
     - name: Install Rust
       id: rust
       run: |
         case ${OS_NAME} in
           debian|ubuntu)
+            apt-get update
             apt-get install -y curl
             ;;
         esac
@@ -988,6 +989,8 @@ jobs:
             apt-get install -y binutils gcc dpkg-dev jq lintian pkg-config ${{ inputs.deb_extra_build_packages }}
             ;;
           centos|rockylinux)
+            #sed -i -e 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf || true
+            yum update -y # See: https://github.com/NLnetLabs/ploutos/issues/90
             yum install epel-release -y
             yum install -y findutils gcc jq ${{ inputs.rpm_extra_build_packages }}
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -410,6 +410,17 @@ jobs:
             fi
           fi
 
+          # Exclude debian:stretch as its GLIBC is too old to support Node 20 now required to use GitHub Actions
+          if [[ "${PACKAGE_BUILD_RULES_PROCESSED_JSON}" != "{}" ]]; then
+            CONTROL_JSON=$(echo ${PACKAGE_BUILD_RULES_PROCESSED_JSON} | jq -c)
+            MODIFIED_JSON=$(echo ${PACKAGE_BUILD_RULES_PROCESSED_JSON} | jq -c 'del(.image[]? | select(. == "debian:stretch")) | del(.include[]? | select(.image == "debian:stretch"))')
+            MODIFIED_JSON=$(echo ${MODIFIED_JSON} | jq -c 'del(.include[]? | select(.os == "debian:stretch"))')
+            if [[ "${CONTROL_JSON}" != "${MODIFIED_JSON}" ]]; then
+              echo "::warning::Removed debian:stretch image from package_build_rules because its GLIBC is too old to support Node 20 required by GitHub Actions"
+              PACKAGE_BUILD_RULES_PROCESSED_JSON="${MODIFIED_JSON}"
+            fi
+          fi
+
           echo "package_build_rules<<END_OF_PACKAGE_BUILD_RULES" >> $GITHUB_OUTPUT
           echo ${PACKAGE_BUILD_RULES_PROCESSED_JSON} | jq >> $GITHUB_OUTPUT
           echo 'END_OF_PACKAGE_BUILD_RULES' >> $GITHUB_OUTPUT


### PR DESCRIPTION
This release contains the following changes:

- Remove support for Ubuntu 18.04 LTS (Bionic Beaver) and Debian 9 (Stretch) (#125).

Successful test runs can be seen here:

- dev branch: https://github.com/NLnetLabs/ploutos-testing/actions/runs/12121355629
- main branch: https://github.com/NLnetLabs/ploutos-testing/actions/runs/12123222968
- release tag: TODO

Release checklist:

- [x] 1. Create a branch in the RELEASE repo, let's call this the RELEASE branch.
- [ ] 2. Change RPM_MACROS_URL in the workflow to point to the new RELEASE branch.
- [x] 3. Create a PR in the RELEASE repo for the RELEASE branch.
- [x] 4. Create a matching branch in the TEST repo, let's call this the TEST branch.
- [x] 5. Make the desired changes to the RELEASE branch.
- [x] 6. In the TEST branch modify `.github/workflows/pkg.yml` so that instead of referring to `pkg-rust.yml@vX` it refers to `pkg-rust.yml@<Git ref of HEAD commit on the TEST branch>` or `pkg-rust.yml@<test branch name>`.
- [x] 7. Create a PR in the `ploutos-testing` repository from the TEST branch to `main`, let's call this the TEST PR.
- [x] 8. Repeat step 5 until the the `Packaging` workflow run in the TEST PR passes and behaves as desired.
- [x] 9. Merge the TEST PR to the `main` branch.
- [x] 10. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo against the `main` branch passes and behaves as desired. If not, repeat steps 4-9 until the new TEST PR passes and behaves as desired.
- [x] 11. Create a release tag in the TEST repo with the same release tag as will be used in the RELEASE repo, e.g. v1.2.3. _**Note:** Remember to respect semantic versioning, i.e. if the changes being made are not backward compatible you will need to bump the MAJOR version (in MAJOR.MINOR.PATCH) **and** any workflows that invoke the reusable workflow will need to be **manually edited** to refer to the new MAJOR version._
- [x] 12. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo passes against the newly created release tag passes and behaves as desired. If not, delete the release tag **in the TEST repo** and repeat steps 4-11 until the new TEST PR passes and behaves as desired.
- [x] 13. Merge the RELEASE PR to the `main` branch.
- [ ] 14. Change RPM_MACROS_URL in the workflow to point to vX.Y.Z tag (if your release branch has a different name).
- [x] 15. Create the new release vX.Y.Z tag in the RELEASE repo.
- [x] 16. Update the vX tag in the RELEASE repo to point to the new vX.Y.Z tag ([howto](https://github.com/NLnetLabs/ploutos/blob/main/docs/develop/README.md#release-process)).
- [x] 17. Edit `.github/workflows/pkg.yml` in the `main` branch of the TEST repo to refer again to `@vX`.
- [x] 18. Verify that the `Packaging` action in the TEST repo against the `main` branch passes and works as desired.
- [ ] 19. (optional) If the MAJOR version was changed, update affected repositories that use the reusable workflow to use the new MAJOR version, including adjusting to any breaking changes introduced by the MAJOR version change.
