### PR TITLE
Fix Trixie, Focal, and Alma Linux 10

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -528,6 +528,17 @@ jobs:
             fi
           fi
 
+          # Exclude almalinux:10 because the LXC image is not yet available.
+          if [[ "${PACKAGE_TEST_RULES_PROCESSED_JSON}" != "{}" ]]; then
+            CONTROL_JSON=$(echo ${PACKAGE_TEST_RULES_PROCESSED_JSON} | jq -c)
+            MODIFIED_JSON=$(echo ${PACKAGE_TEST_RULES_PROCESSED_JSON} | jq -c 'del(.image[]? | select(. == "almalinux:10")) | del(.include[]? | select(.image == "almalinux:10"))')
+            MODIFIED_JSON=$(echo ${MODIFIED_JSON} | jq -c 'del(.include[]? | select(.os == "almalinux:10"))')
+            if [[ "${CONTROL_JSON}" != "${MODIFIED_JSON}" ]]; then
+              echo "::warning::Removed almalinux:10 image from package_test_rules because the LXC/Incus image no longer exists"
+              PACKAGE_TEST_RULES_PROCESSED_JSON="${MODIFIED_JSON}"
+            fi
+          fi
+
           # Exclude non-x86_64 targets as we only run the tests on x86-64 GitHub runners.
           if [[ "${PACKAGE_TEST_RULES_PROCESSED_JSON}" != "{}" ]]; then
             CONTROL_JSON=$(echo ${PACKAGE_TEST_RULES_PROCESSED_JSON} | jq -c)

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1999,7 +1999,7 @@ jobs:
             fi
             sudo incus exec testcon -- sed -i -e "s/\${OS_NAME}/${OS_NAME}/g" -e "s/\${OS_REL}/${OS_REL}/g" /etc/apt/sources.list.d/ploutos.list
             sudo incus exec testcon -- wget -q ${{ steps.verify.outputs.deb_apt_key_url }} -Oaptkey.asc
-            sudo incus exec testcon -- gpg --dearmor -o /etc/apt/trusted.gpg.d/nlnetlabs-archive-keyring.asc ./aptkey.asc
+            sudo incus exec testcon -- gpg --dearmor -o /etc/apt/trusted.gpg.d/nlnetlabs-archive-keyring.gpg ./aptkey.asc
             sudo incus exec testcon -- apt-get -y update
             sudo incus exec testcon -- apt-get install -y ${{ steps.verify.outputs.published_pkg }}
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -528,6 +528,17 @@ jobs:
             fi
           fi
 
+          # Exclude ubuntu:focal because the LXC image is no longer available.
+          if [[ "${PACKAGE_TEST_RULES_PROCESSED_JSON}" != "{}" ]]; then
+            CONTROL_JSON=$(echo ${PACKAGE_TEST_RULES_PROCESSED_JSON} | jq -c)
+            MODIFIED_JSON=$(echo ${PACKAGE_TEST_RULES_PROCESSED_JSON} | jq -c 'del(.image[]? | select(. == "ubuntu:focal")) | del(.include[]? | select(.image == "ubuntu:focal"))')
+            MODIFIED_JSON=$(echo ${MODIFIED_JSON} | jq -c 'del(.include[]? | select(.os == "ubuntu:focal"))')
+            if [[ "${CONTROL_JSON}" != "${MODIFIED_JSON}" ]]; then
+              echo "::warning::Removed ubuntu:focal image from package_test_rules because the LXC/Incus image no longer exists"
+              PACKAGE_TEST_RULES_PROCESSED_JSON="${MODIFIED_JSON}"
+            fi
+          fi
+
           # Exclude almalinux:10 because the LXC image is not yet available.
           if [[ "${PACKAGE_TEST_RULES_PROCESSED_JSON}" != "{}" ]]; then
             CONTROL_JSON=$(echo ${PACKAGE_TEST_RULES_PROCESSED_JSON} | jq -c)

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1999,7 +1999,7 @@ jobs:
             fi
             sudo incus exec testcon -- sed -i -e "s/\${OS_NAME}/${OS_NAME}/g" -e "s/\${OS_REL}/${OS_REL}/g" /etc/apt/sources.list.d/ploutos.list
             sudo incus exec testcon -- wget -q ${{ steps.verify.outputs.deb_apt_key_url }} -Oaptkey.asc
-            sudo incus exec testcon -- gpg --dearmor -o ./aptkey.asc
+            sudo incus exec testcon -- cat ./aptkey.asc | gpg --dearmor -o /usr/share/keyrings/nlnetlabs-archive-keyring.gpg
             sudo incus exec testcon -- apt-get -y update
             sudo incus exec testcon -- apt-get install -y ${{ steps.verify.outputs.published_pkg }}
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1999,7 +1999,7 @@ jobs:
             fi
             sudo incus exec testcon -- sed -i -e "s/\${OS_NAME}/${OS_NAME}/g" -e "s/\${OS_REL}/${OS_REL}/g" /etc/apt/sources.list.d/ploutos.list
             sudo incus exec testcon -- wget -q ${{ steps.verify.outputs.deb_apt_key_url }} -Oaptkey.asc
-            sudo incus exec testcon -- cat ./aptkey.asc | gpg --dearmor -o /usr/share/keyrings/nlnetlabs-archive-keyring.gpg
+            sudo incus exec testcon -- cat ./aptkey.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/nlnetlabs-archive-keyring.asc
             sudo incus exec testcon -- apt-get -y update
             sudo incus exec testcon -- apt-get install -y ${{ steps.verify.outputs.published_pkg }}
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1999,7 +1999,7 @@ jobs:
             fi
             sudo incus exec testcon -- sed -i -e "s/\${OS_NAME}/${OS_NAME}/g" -e "s/\${OS_REL}/${OS_REL}/g" /etc/apt/sources.list.d/ploutos.list
             sudo incus exec testcon -- wget -q ${{ steps.verify.outputs.deb_apt_key_url }} -Oaptkey.asc
-            sudo incus exec testcon -- apt-key add ./aptkey.asc
+            sudo incus exec testcon -- gpg --dearmor -o ./aptkey.asc
             sudo incus exec testcon -- apt-get -y update
             sudo incus exec testcon -- apt-get install -y ${{ steps.verify.outputs.published_pkg }}
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1999,7 +1999,7 @@ jobs:
             fi
             sudo incus exec testcon -- sed -i -e "s/\${OS_NAME}/${OS_NAME}/g" -e "s/\${OS_REL}/${OS_REL}/g" /etc/apt/sources.list.d/ploutos.list
             sudo incus exec testcon -- wget -q ${{ steps.verify.outputs.deb_apt_key_url }} -Oaptkey.asc
-            sudo incus exec testcon -- cat ./aptkey.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/nlnetlabs-archive-keyring.asc
+            sudo incus exec testcon -- gpg --dearmor -o /etc/apt/trusted.gpg.d/nlnetlabs-archive-keyring.asc ./aptkey.asc
             sudo incus exec testcon -- apt-get -y update
             sudo incus exec testcon -- apt-get install -y ${{ steps.verify.outputs.published_pkg }}
 


### PR DESCRIPTION
This release contains the following changes:

- Replace apt-key with gpg as it is deprecated in Trixie
- Exclude testing for Alma Linux 10 as it still does not have LXC images
- Exclude testing for Ubuntu Focal as it no longer has LXC images

Successful test runs can be seen here:

- dev branch: https://github.com/NLnetLabs/ploutos-testing/actions/runs/16626432481
- main branch: https://github.com/NLnetLabs/ploutos-testing/actions/runs/16626629775
- release tag: https://github.com/NLnetLabs/ploutos-testing/actions/runs/16626649297

Release checklist:

- [x] 1. Create a branch in the RELEASE repo, let's call this the RELEASE branch.
- [ ] 2. Change RPM_MACROS_URL in the workflow to point to the new RELEASE branch.
- [x] 3. Create a PR in the RELEASE repo for the RELEASE branch.
- [x] 4. Create a matching branch in the TEST repo, let's call this the TEST branch.
- [x] 5. Make the desired changes to the RELEASE branch.
- [x] 6. In the TEST branch modify `.github/workflows/pkg.yml` so that instead of referring to `pkg-rust.yml@vX` it refers to `pkg-rust.yml@<Git ref of HEAD commit on the TEST branch>` or `pkg-rust.yml@<test branch name>`.
- [x] 7. Create a PR in the `ploutos-testing` repository from the TEST branch to `main`, let's call this the TEST PR.
- [x] 8. Repeat step 5 until the the `Packaging` workflow run in the TEST PR passes and behaves as desired.
- [x] 9. Merge the TEST PR to the `main` branch.
- [x] 10. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo against the `main` branch passes and behaves as desired. If not, repeat steps 4-9 until the new TEST PR passes and behaves as desired.
- [x] 11. Create a release tag in the TEST repo with the same release tag as will be used in the RELEASE repo, e.g. v1.2.3. _**Note:** Remember to respect semantic versioning, i.e. if the changes being made are not backward compatible you will need to bump the MAJOR version (in MAJOR.MINOR.PATCH) **and** any workflows that invoke the reusable workflow will need to be **manually edited** to refer to the new MAJOR version._
- [x] 12. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo passes against the newly created release tag passes and behaves as desired. If not, delete the release tag **in the TEST repo** and repeat steps 4-11 until the new TEST PR passes and behaves as desired.
- [x] 13. Merge the RELEASE PR to the `main` branch.
- [x] 14. Change RPM_MACROS_URL in the workflow to point to vX.Y.Z tag (if your release branch has a different name).
- [x] 15. Create the new release vX.Y.Z tag in the RELEASE repo.
- [x] 16. Update the vX tag in the RELEASE repo to point to the new vX.Y.Z tag ([howto](https://github.com/NLnetLabs/ploutos/blob/main/docs/develop/README.md#release-process)).
- [x] 17. Edit `.github/workflows/pkg.yml` in the `main` branch of the TEST repo to refer again to `@vX`.
- [ ] 18. Verify that the `Packaging` action in the TEST repo against the `main` branch passes and works as desired.
- [ ] 19. (optional) If the MAJOR version was changed, update affected repositories that use the reusable workflow to use the new MAJOR version, including adjusting to any breaking changes introduced by the MAJOR version change.
