### PR TITLE
Handle Debian SystemD service file naming patterns when preparing input for cargo-generate-rpm.

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -276,6 +276,11 @@ on:
         type: string
         default: ''
 
+      package_test_always_add_repo:
+          description: "When testing a package, always add deb_apt_source and/or rpm_yum_repo, not only during package upgrade testing."
+          required: false
+          type: boolean
+          default: false
       package_test_scripts_path:
         description: "The path to find scripts for running tests. Invoked scripts take a single argument: post-install or post-upgrade."
         required: false
@@ -2007,6 +2012,7 @@ jobs:
         esac
 
     - name: Configure extra package repo
+      if: ${{ inputs.always_add_repo }}
       run: |
         case ${OS_NAME} in
           debian|ubuntu)

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -2006,9 +2006,7 @@ jobs:
             ;;
         esac
 
-    - name: Install previously published package
-      id: instprev
-      if: ${{ steps.verify.outputs.mode == 'upgrade-from-published' }}
+    - name: Configure extra package repo
       run: |
         case ${OS_NAME} in
           debian|ubuntu)
@@ -2022,6 +2020,25 @@ jobs:
             sudo incus exec testcon -- wget -q ${{ steps.verify.outputs.deb_apt_key_url }} -Oaptkey.asc
             sudo incus exec testcon -- gpg --dearmor -o /etc/apt/trusted.gpg.d/nlnetlabs-archive-keyring.gpg ./aptkey.asc
             sudo incus exec testcon -- apt-get -y update
+            ;;
+          centos|rockylinux|almalinux)
+            if [[ -f '${{ steps.verify.outputs.rpm_yum_repo }}' ]]; then
+              sudo incus file push ${{ steps.verify.outputs.rpm_yum_repo }} testcon/etc/yum.repos.d/ploutos.repo
+            else
+              echo -e '${{ steps.verify.outputs.rpm_yum_repo }}' >$HOME/ploutos.repo
+              sudo incus file push $HOME/ploutos.repo testcon/etc/yum.repos.d/
+            fi
+            sudo incus exec testcon -- sed -i -e "s/\${OS_NAME}/${OS_NAME}/g" -e "s/\${OS_REL}/${OS_REL}/g" /etc/yum.repos.d/ploutos.repo
+            sudo incus exec testcon -- rpm --import ${{ steps.verify.outputs.rpm_yum_key_url }}
+            ;;
+        esac
+
+    - name: Install previously published package
+      id: instprev
+      if: ${{ steps.verify.outputs.mode == 'upgrade-from-published' }}
+      run: |
+        case ${OS_NAME} in
+          debian|ubuntu)
             sudo incus exec testcon -- apt-get install -y ${{ steps.verify.outputs.published_pkg }}
 
             if [[ "${{ steps.verify.outputs.pkg }}" == "${{ steps.verify.outputs.published_pkg }}" ]]; then

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -2012,7 +2012,7 @@ jobs:
         esac
 
     - name: Configure extra package repo
-      if: ${{ inputs.always_add_repo }}
+      if: ${{ steps.verify.outputs.mode == 'upgrade-from-published'  || inputs.package_test_always_add_repo }}
       run: |
         case ${OS_NAME} in
           debian|ubuntu)

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1407,7 +1407,17 @@ jobs:
 
             if [ -e "${SYSTEMD_SERVICE_UNIT_FILE}" ]; then
                 mkdir -p ${TARGET_DIR}/rpm/
-                cp ${SYSTEMD_SERVICE_UNIT_FILE} ${TARGET_DIR}/rpm/${MATRIX_PKG}.service
+                # Parse the Debian SystemD script file naming which the user may have used for input to cargo-deb
+                # but which we will then also have to deal with as well:
+                #   <package>.<unit>.<script> - strip out <package> and use the rest
+                #   <package.<script>         - use as-is
+                #   <unit>.<script>           - use as-is
+                #   <script>                  - use as-is
+                if [[ "${SYSTEMD_SERVICE_UNIT_FILE}" =~ ^[^.]+\.([^.]+\.[^.]+)$ ]]; then
+                    cp ${SYSTEMD_SERVICE_UNIT_FILE} ${TARGET_DIR}/rpm/${BASH_REMATCH[1]}
+                else
+                    cp ${SYSTEMD_SERVICE_UNIT_FILE} ${TARGET_DIR}/rpm/
+                fi
             elif [[ "${SYSTEMD_SERVICE_UNIT_FILE}" == *"*" ]]; then
                 mkdir -p ${TARGET_DIR}/rpm/
                 cp ${SYSTEMD_SERVICE_UNIT_FILE} ${TARGET_DIR}/rpm


### PR DESCRIPTION
This hopefully backward compatible but possibly breaking release contains the following changes:

- [#140]
- Make the `rpm_yum_repo` and `deb_apt_source` repos always available if new setting `package_test_always_add_repo` is set to true, not only when installing a previously published packages. This then allows installation of a previously published package to depend on packages in the supplied repo.

Successful test runs can be seen here:

- dev branch: https://github.com/NLnetLabs/ploutos-testing/actions/runs/17416677522
- main branch: TODO
- release tag: TODO

Release checklist:

- [x] 1. Create a branch in the RELEASE repo, let's call this the RELEASE branch.
- [ ] 2. Change RPM_MACROS_URL in the workflow to point to the new RELEASE branch.
- [x] 3. Create a PR in the RELEASE repo for the RELEASE branch.
- [ ] 4. Create a matching branch in the TEST repo, let's call this the TEST branch.
- [x] 5. Make the desired changes to the RELEASE branch.
- [x] 6. In the TEST branch modify `.github/workflows/pkg.yml` so that instead of referring to `pkg-rust.yml@vX` it refers to `pkg-rust.yml@<Git ref of HEAD commit on the TEST branch>` or `pkg-rust.yml@<test branch name>`.
- [x] 7. Create a PR in the `ploutos-testing` repository from the TEST branch to `main`, let's call this the TEST PR.
- [x] 8. Repeat step 5 until the the `Packaging` workflow run in the TEST PR passes and behaves as desired.
- [x] 9. Merge the TEST PR to the `main` branch.
- [x] 10. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo against the `main` branch passes and behaves as desired. If not, repeat steps 4-9 until the new TEST PR passes and behaves as desired.
- [x] 11. Create a release tag in the TEST repo with the same release tag as will be used in the RELEASE repo, e.g. v1.2.3. _**Note:** Remember to respect semantic versioning, i.e. if the changes being made are not backward compatible you will need to bump the MAJOR version (in MAJOR.MINOR.PATCH) **and** any workflows that invoke the reusable workflow will need to be **manually edited** to refer to the new MAJOR version._
- [x] 12. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo passes against the newly created release tag passes and behaves as desired. If not, delete the release tag **in the TEST repo** and repeat steps 4-11 until the new TEST PR passes and behaves as desired.
- [ ] 13. Merge the RELEASE PR to the `main` branch.
- [ ] 14. Change RPM_MACROS_URL in the workflow to point to vX.Y.Z tag (if your release branch has a different name).
- [ ] 15. Create the new release vX.Y.Z tag in the RELEASE repo.
- [ ] 16. Update the vX tag in the RELEASE repo to point to the new vX.Y.Z tag ([howto](https://github.com/NLnetLabs/ploutos/blob/main/docs/develop/README.md#release-process)).
- [ ] 17. Edit `.github/workflows/pkg.yml` in the `main` branch of the TEST repo to refer again to `@vX`.
- [ ] 18. Verify that the `Packaging` action in the TEST repo against the `main` branch passes and works as desired.
- [ ] 19. (optional) If the MAJOR version was changed, update affected repositories that use the reusable workflow to use the new MAJOR version, including adjusting to any breaking changes introduced by the MAJOR version change.
