### PR TITLE
Fix systemd rpm macros

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1449,7 +1449,7 @@ jobs:
             # command line argument.
             if [ -f "${RPM_SCRIPTLETS_PATH}" ]; then
               # Download the RPM systemd macros shell functions file fragment
-              SYSTEMD_RPM_MACROS_URL="https://raw.githubusercontent.com/NLnetLabs/ploutos/v8/fragments/macros.systemd.sh"
+              SYSTEMD_RPM_MACROS_URL="https://raw.githubusercontent.com/NLnetLabs/ploutos/fix-systemd-rpm-macros/fragments/macros.systemd.sh"
               SYSTEMD_RPM_MACROS_FILE="/tmp/systemd_rpm_macros"
               curl --proto '=https' --tlsv1.2 --fail --output ${SYSTEMD_RPM_MACROS_FILE} ${SYSTEMD_RPM_MACROS_URL}
 

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1453,6 +1453,11 @@ jobs:
               SYSTEMD_RPM_MACROS_FILE="/tmp/systemd_rpm_macros"
               curl --proto '=https' --tlsv1.2 --fail --output ${SYSTEMD_RPM_MACROS_FILE} ${SYSTEMD_RPM_MACROS_URL}
 
+              # Bash 5.2 introduced the option patsub_replacement, which makes pattern substitution replace
+              # all occurances of `&` in the replacement string ($value in the case below) with the matched pattern
+              # (#RPM_SYSTEMD_MACROS# in the case below). The following line disables that behavior, if that option exists.
+              shopt | grep -q "^patsub_replacement" && shopt -u patsub_replacement
+
               # Replace any reference to #SYSTEMD_RPM_MACROS# in the scriptlet file with the downloaded RPM systemd macros
               # shell fragment.
               SCRIPTLET_FILE="${{ inputs.rpm_scriptlets_path }}"

--- a/fragments/macros.systemd.sh
+++ b/fragments/macros.systemd.sh
@@ -16,15 +16,15 @@
 systemd_update_helper_v239() {
     case "$command" in
         install-system-units)
-            systemctl --no-reload preset "$@" \&>/dev/null
+            systemctl --no-reload preset "$@" &>/dev/null
             ;;
 
         remove-system-units)
-            systemctl --no-reload disable --now "$@" \&>/dev/null
+            systemctl --no-reload disable --now "$@" &>/dev/null
             ;;
 
         mark-restart-system-units)
-            systemctl try-restart "$@" \&>/dev/null 2>\&1
+            systemctl try-restart "$@" &>/dev/null 2>&1
             ;;
 
         system-reload)
@@ -36,16 +36,16 @@ systemd_update_helper_v239() {
 systemd_update_helper_v219() {
     case "$command" in
         install-system-units)
-            systemctl preset "$@" \&>/dev/null 2>\&1
+            systemctl preset "$@" &>/dev/null 2>&1
             ;;
 
         remove-system-units)
-            systemctl --no-reload disable "$@" > /dev/null 2>\&1
-            systemctl stop "$@" > /dev/null 2>\&1
+            systemctl --no-reload disable "$@" > /dev/null 2>&1
+            systemctl stop "$@" > /dev/null 2>&1
             ;;
 
         mark-restart-system-units)
-            systemctl try-restart "$@" >/dev/null 2>\&1
+            systemctl try-restart "$@" >/dev/null 2>&1
             ;;
 
         system-reload)


### PR DESCRIPTION
This release contains the following changes:

- Revert #134's escaping of ampersands, as it breaks packages for AlmaLinux 8 and 9.
- Disable the `patsub_replacement` bash shell option if it exists. Bash introduced this shell option and behavior in version 5.2 (included from almalinux10 onward; almalinux9 still uses bash 5.1).

Successful test runs can be seen here:

- dev branch: https://github.com/NLnetLabs/ploutos-testing/actions/runs/18344482174
- main branch: https://github.com/NLnetLabs/ploutos-testing/actions/runs/18344651402
- release tag: https://github.com/NLnetLabs/ploutos-testing/actions/runs/18344908549

Release checklist:

- [x] 1. Create a branch in the RELEASE repo, let's call this the RELEASE branch.
- [x] 2. Change RPM_MACROS_URL in the workflow to point to the new RELEASE branch.
- [x] 3. Create a PR in the RELEASE repo for the RELEASE branch.
- [x] 4. Create a matching branch in the TEST repo, let's call this the TEST branch. (Oops, has a different name: ampersand-fix-with-shopt)
- [x] 5. Make the desired changes to the RELEASE branch.
- [x] 6. In the TEST branch modify `.github/workflows/pkg.yml` so that instead of referring to `pkg-rust.yml@vX` it refers to `pkg-rust.yml@<Git ref of HEAD commit on the TEST branch>` or `pkg-rust.yml@<test branch name>`.
- [x] 7. Create a PR in the `ploutos-testing` repository from the TEST branch to `main`, let's call this the TEST PR.
- [x] 8. Repeat step 5 until the the `Packaging` workflow run in the TEST PR passes and behaves as desired.
- [x] 9. Merge the TEST PR to the `main` branch.
- [x] 10. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo against the `main` branch passes and behaves as desired. If not, repeat steps 4-9 until the new TEST PR passes and behaves as desired.
- [x] 11. Create a release tag in the TEST repo with the same release tag as will be used in the RELEASE repo, e.g. v1.2.3. _**Note:** Remember to respect semantic versioning, i.e. if the changes being made are not backward compatible you will need to bump the MAJOR version (in MAJOR.MINOR.PATCH) **and** any workflows that invoke the reusable workflow will need to be **manually edited** to refer to the new MAJOR version._
- [x] 12. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo passes against the newly created release tag passes and behaves as desired. If not, delete the release tag **in the TEST repo** and repeat steps 4-11 until the new TEST PR passes and behaves as desired.
- [x] 13. Merge the RELEASE PR to the `main` branch.
- [x] 14. Change RPM_MACROS_URL in the workflow to point to vX.Y.Z tag (if your release branch has a different name).
- [x] 15. Create the new release vX.Y.Z tag in the RELEASE repo.
- [x] 16. Update the vX tag in the RELEASE repo to point to the new vX.Y.Z tag ([howto](https://github.com/NLnetLabs/ploutos/blob/main/docs/develop/README.md#release-process)).
- [x] 17. Edit `.github/workflows/pkg.yml` in the `main` branch of the TEST repo to refer again to `@vX`.
- [x] 18. Verify that the `Packaging` action in the TEST repo against the `main` branch passes and works as desired.
- [ ] 19. (optional) If the MAJOR version was changed, update affected repositories that use the reusable workflow to use the new MAJOR version, including adjusting to any breaking changes introduced by the MAJOR version change.
