### PR TITLE
Fix rpm scriptlets and cross built binaries paths when manifest_dir is set

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -895,7 +895,12 @@ jobs:
       if: ${{ steps.skip.skip != 'true' }}
       run: |
         rm -f bins.tar
-        find target/${{ matrix.target }}/release/ -maxdepth 1 -type f -executable | xargs tar vpcf bins.tar
+        if [[ -z "${{ inputs.manifest_dir }}" ]]; then
+          CROSS_FIND_BASE=.
+        else
+          CROSS_FIND_BASE="${{ inputs.manifest_dir }}"
+        fi
+        find "$CROSS_FIND_BASE/target/${{ matrix.target }}/release/" -maxdepth 1 -type f -executable | xargs tar vpcf bins.tar
 
     # Upload cross compiled binaries as GitHub Actions artifacts for use by the `pkg` job below. We can't use job
     # outputs as those are limited to 50 MB which we could easily exceed. We can't use actions/cache as cached items

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1441,6 +1441,13 @@ jobs:
                      ${{ needs.prepare.outputs.cargo_package_toml_path }}
             fi
 
+            # If the manifest_dir is set, we will change the working directory down
+            # below. Therfore, we need to create a path to the scriptlets file that
+            # is relative to that working directory instead of the git repo's root.
+            if [[ -n "${{ inputs.manifest_dir }}" ]]; then
+              MANIFEST_RELATIVE_SCRIPTLETS_PATH=$(realpath --relative-to "${{ inputs.manifest_dir }}" "${RPM_SCRIPTLETS_PATH}")
+            fi
+
             # https://github.com/NLnetLabs/krill/issues/907
             # cargo-generate-rpm doesn't support setting scripts to files, and we can't refer to a file that 
             # installed such as /usr/share/krill/rpm/postuninst because 'yum remove' removes the file before it
@@ -1467,7 +1474,11 @@ jobs:
               echo "${templ//#RPM_SYSTEMD_MACROS#/$value}" > "$SCRIPTLET_FILE"
 
               # Configure ourselves to use the updated scriptlets file as input to cargo generate-rpm.
-              SCRIPTLETS='--metadata-overwrite=${{ inputs.rpm_scriptlets_path }}'
+              if [[ -n "$MANIFEST_RELATIVE_SCRIPTLETS_PATH" ]]; then
+                SCRIPTLETS="--metadata-overwrite=$MANIFEST_RELATIVE_SCRIPTLETS_PATH"
+              else
+                SCRIPTLETS='--metadata-overwrite=${{ inputs.rpm_scriptlets_path }}'
+              fi
             fi
 
             find ${TARGET_DIR}/release -maxdepth 1 -type f -executable | xargs strip -s -v

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1449,7 +1449,7 @@ jobs:
             # If the manifest_dir is set, we will change the working directory down
             # below. Therfore, we need to create a path to the scriptlets file that
             # is relative to that working directory instead of the git repo's root.
-            if [[ -n "${{ inputs.manifest_dir }}" ]]; then
+            if [[ -n "${{ inputs.manifest_dir }}" && -f "${RPM_SCRIPTLETS_PATH}" ]]; then
               MANIFEST_RELATIVE_SCRIPTLETS_PATH=$(realpath --relative-to "${{ inputs.manifest_dir }}" "${RPM_SCRIPTLETS_PATH}")
             fi
 


### PR DESCRIPTION
This release contains the following changes:

- Refer to the rpm scriptlets file relative to the manifest_dir, if manifest_dir is set
- Respect manifest_dir in finding executables in cross compilation step

**Scriptlet path error**
encountered here: https://github.com/NLnetLabs/dnst/actions/runs/19769529400/job/56650598230#step:24:603
Minimal local reproducer:
```
$ cargo generate-rpm --set-metadata 'version="0.1.1~rc1"' --metadata-overwrite=pkg/dnst-ldnsutils/pkg/rpm/scriptlets.toml
No such file or directory (os error 2)
$ l ..
.rwxr-xr-x 3.9k mozzie mozzie 28 Nov 18:11 create-scriplet.sh
drwxr-xr-x    - mozzie mozzie 28 Nov 18:12 dnst-ldnsutils
.rw-r--r-- 3.8k mozzie mozzie 28 Nov 18:14 scriptlets.toml
$ cargo generate-rpm --set-metadata 'version="0.1.1~rc1"' --metadata-overwrite=../scriptlets.toml
Asset file not found: ../../doc/manual/build/man/ldns-key2ds.1
```
success: https://github.com/NLnetLabs/dnst/actions/runs/19773791618/job/56662927355

**cross-compile with manifest_dir**

error:
- https://github.com/NLnetLabs/dnst/actions/runs/19773387929/job/56661769447#step:10:8
- https://github.com/NLnetLabs/dnst/actions/runs/19773387929/job/56661769447#step:11:12

success:
- https://github.com/NLnetLabs/dnst/actions/runs/19773791618/job/56662927313#step:10:19

**Successful test runs can be seen here:**

- dev branch: https://github.com/NLnetLabs/ploutos-testing/actions/runs/19774635738
- main branch: https://github.com/NLnetLabs/ploutos-testing/actions/runs/19774868958
- release tag: https://github.com/NLnetLabs/ploutos-testing/actions/runs/19775164918

Release checklist:

- [x] 1. Create a branch in the RELEASE repo, let's call this the RELEASE branch.
- [ ] 2. Change RPM_MACROS_URL in the workflow to point to the new RELEASE branch.
- [x] 3. Create a PR in the RELEASE repo for the RELEASE branch.
- [x] 4. Create a matching branch in the TEST repo, let's call this the TEST branch.
- [x] 5. Make the desired changes to the RELEASE branch.
- [x] 6. In the TEST branch modify `.github/workflows/pkg.yml` so that instead of referring to `pkg-rust.yml@vX` it refers to `pkg-rust.yml@<Git ref of HEAD commit on the TEST branch>` or `pkg-rust.yml@<test branch name>`.
- [x] 7. Create a PR in the `ploutos-testing` repository from the TEST branch to `main`, let's call this the TEST PR.
- [x] 8. Repeat step 5 until the the `Packaging` workflow run in the TEST PR passes and behaves as desired.
- [x] 9. Merge the TEST PR to the `main` branch.
- [x] 10. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo against the `main` branch passes and behaves as desired. If not, repeat steps 4-9 until the new TEST PR passes and behaves as desired.
- [x] 11. Create a release tag in the TEST repo with the same release tag as will be used in the RELEASE repo, e.g. v1.2.3. _**Note:** Remember to respect semantic versioning, i.e. if the changes being made are not backward compatible you will need to bump the MAJOR version (in MAJOR.MINOR.PATCH) **and** any workflows that invoke the reusable workflow will need to be **manually edited** to refer to the new MAJOR version._
- [x] 12. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo passes against the newly created release tag passes and behaves as desired. If not, delete the release tag **in the TEST repo** and repeat steps 4-11 until the new TEST PR passes and behaves as desired.
- [x] 13. Merge the RELEASE PR to the `main` branch.
- [x] 14. Change RPM_MACROS_URL in the workflow to point to vX.Y.Z tag (if your release branch has a different name).
- [x] 15. Create the new release vX.Y.Z tag in the RELEASE repo.
- [x] 16. Update the vX tag in the RELEASE repo to point to the new vX.Y.Z tag ([howto](https://github.com/NLnetLabs/ploutos/blob/main/docs/develop/README.md#release-process)).
- [x] 17. Edit `.github/workflows/pkg.yml` in the `main` branch of the TEST repo to refer again to `@vX`.
- [x] 18. Verify that the `Packaging` action in the TEST repo against the `main` branch passes and works as desired.
- [ ] 19. (optional) If the MAJOR version was changed, update affected repositories that use the reusable workflow to use the new MAJOR version, including adjusting to any breaking changes introduced by the MAJOR version change.
