### PR TITLE
Try to fix Docker `client version 1.42 is too old. Minimum supported API version is 1.44` error

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -2262,8 +2262,6 @@ jobs:
           platforms: ${{ matrix.platform }}
 
       - uses: docker/setup-buildx-action@v3
-        with:
-          version: v0.9.1 # See: https://github.com/docker/build-push-action/issues/755
 
       - name: Download cross-compiled binaries
         if: ${{ steps.verify.outputs.mode == 'copy' }}
@@ -2312,6 +2310,8 @@ jobs:
             MODE=${{ steps.verify.outputs.mode }}
             CARGO_ARGS=${{ matrix.cargo_args }}
           load: true
+          provenance: false
+          sbom: false
 
       - name: Save Docker image locally
         run: |

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -2352,6 +2352,8 @@ jobs:
             MODE=${{ steps.verify.outputs.mode }}
             CARGO_ARGS=${{ matrix.cargo_args }}
           push: true
+          provenance: false
+          sbom: false
 
 
   # -------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This release contains the following changes:

- Fixes Docker build issue

Successful test runs can be seen here:

- dev branch: https://github.com/NLnetLabs/ploutos-testing/actions/runs/22183249417
- main branch: https://github.com/NLnetLabs/ploutos-testing/actions/runs/22183668086
- release tag: https://github.com/NLnetLabs/ploutos-testing/actions/runs/22184021718

Release checklist:

- [x] 1. Create a branch in the RELEASE repo, let's call this the RELEASE branch.
- [ ] 2. Change RPM_MACROS_URL in the workflow to point to the new RELEASE branch.
- [x] 3. Create a PR in the RELEASE repo for the RELEASE branch.
- [x] 4. Create a matching branch in the TEST repo, let's call this the TEST branch.
- [x] 5. Make the desired changes to the RELEASE branch.
- [x] 6. In the TEST branch modify `.github/workflows/pkg.yml` so that instead of referring to `pkg-rust.yml@vX` it refers to `pkg-rust.yml@<Git ref of HEAD commit on the TEST branch>` or `pkg-rust.yml@<test branch name>`.
- [x] 7. Create a PR in the `ploutos-testing` repository from the TEST branch to `main`, let's call this the TEST PR.
- [x] 8. Repeat step 5 until the the `Packaging` workflow run in the TEST PR passes and behaves as desired.
- [x] 9. Merge the TEST PR to the `main` branch.
- [x] 10. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo against the `main` branch passes and behaves as desired. If not, repeat steps 4-9 until the new TEST PR passes and behaves as desired.
- [x] 11. Create a release tag in the TEST repo with the same release tag as will be used in the RELEASE repo, e.g. v1.2.3. _**Note:** Remember to respect semantic versioning, i.e. if the changes being made are not backward compatible you will need to bump the MAJOR version (in MAJOR.MINOR.PATCH) **and** any workflows that invoke the reusable workflow will need to be **manually edited** to refer to the new MAJOR version._
- [x] 12. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo passes against the newly created release tag passes and behaves as desired. If not, delete the release tag **in the TEST repo** and repeat steps 4-11 until the new TEST PR passes and behaves as desired.
- [x] 13. Merge the RELEASE PR to the `main` branch.
- [x] 14. Change RPM_MACROS_URL in the workflow to point to vX.Y.Z tag (if your release branch has a different name).
- [x] 15. Create the new release vX.Y.Z tag in the RELEASE repo.
- [x] 16. Update the vX tag in the RELEASE repo to point to the new vX.Y.Z tag ([howto](https://github.com/NLnetLabs/ploutos/blob/main/docs/develop/README.md#release-process)).
- [x] 17. Edit `.github/workflows/pkg.yml` in the `main` branch of the TEST repo to refer again to `@vX`.
- [x] 18. Verify that the `Packaging` action in the TEST repo against the `main` branch passes and works as desired.
- [ ] 19. (optional) If the MAJOR version was changed, update affected repositories that use the reusable workflow to use the new MAJOR version, including adjusting to any breaking changes introduced by the MAJOR version change.
