### PR TITLE
Upgrade actions to avoid failure post Sep 16 2026 due to node20 deprecation. (closes #149)

### DIFF
--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -1070,6 +1070,18 @@ jobs:
         case ${OS_NAME} in
           debian|ubuntu)
             apt-get install -y binutils gcc dpkg-dev jq lintian pkg-config ${{ inputs.deb_extra_build_packages }}
+
+            case ${OS_REL} in
+              xenial|bionic|focal|jammy|noble)
+                ;;
+
+              *)
+                # Fix for https://github.com/NLnetLabs/ploutos/issues/145.
+                # Currently appears to affect Ubuntu Resolute Raccoon 26.04
+                # but may also be needed for future releases too.
+                apt-get install -y gcc-multilib
+                ;;
+            esac
             ;;
           centos|rockylinux|almalinux)
             #sed -i -e 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf || true

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -774,7 +774,7 @@ jobs:
       # tag.
       - name: Apply rules to Git metadata to generate potential Docker tags
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ inputs.docker_repo }}
           flavor: |

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -721,7 +721,7 @@ jobs:
 
       - name: Verify Docker credentials
         if: ${{ steps.pre_process_rules.outputs.docker_build_rules != '{}' && fromJSON(steps.verify_inputs.outputs.has_docker_secrets) == true }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_HUB_ID }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
@@ -2336,7 +2336,7 @@ jobs:
 
       - name: Log into Docker Hub
         if: ${{ fromJSON(needs.prepare.outputs.has_docker_secrets) == true }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_HUB_ID }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
@@ -2382,7 +2382,7 @@ jobs:
     runs-on: ${{ inputs.runs_on }}
     steps:
       - name: Log into Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_HUB_ID }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -308,8 +308,6 @@ defaults:
 
 env:
   DEBIAN_FRONTEND: noninteractive
-  # See: https://github.com/actions/checkout/issues/1809
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   # -------------------------------------------------------------------------------------------------------------------

--- a/.github/workflows/pkg-rust.yml
+++ b/.github/workflows/pkg-rust.yml
@@ -336,7 +336,7 @@ jobs:
       package_test_rules: ${{ steps.pre_process_rules.outputs.package_test_rules }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # TODO: extract common code into helper functions
       - name: Pre-process rules
@@ -833,7 +833,7 @@ jobs:
 
     - name: Checkout repository
       if: ${{ steps.skip.skip != 'true' }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     # Install Rust the hard way rather than using a GH Action because the action doesn't work inside a Docker container.
     # Cargo cross "requires a rustup installation of Rust", an O/S package provided Rust won't
@@ -944,7 +944,7 @@ jobs:
         yum install gzip -y
 
     - name: Checkout repository
-      uses: actions/checkout@v3 # v4 doesn't work on containers with older GLIBC such as ubuntu:bionic or centos:7
+      uses: actions/checkout@v7 # v4 doesn't work on containers with older GLIBC such as ubuntu:bionic or centos:7
 
     - name: Print matrix
       # Disable default use of bash -x for easier to read output in the log
@@ -1780,7 +1780,7 @@ jobs:
     steps:
     # Fetch the test scripts that we will run
     - name: Checkout repository
-      uses: actions/checkout@v3 # v4 doesn't work on containers with older GLIBC such as ubuntu:bionic or centos:7
+      uses: actions/checkout@v7 # v4 doesn't work on containers with older GLIBC such as ubuntu:bionic or centos:7
 
     - name: Print matrix
       # Disable default use of bash -x for easier to read output in the log
@@ -2223,7 +2223,7 @@ jobs:
       matrix: ${{ fromJSON(needs.prepare.outputs.docker_build_rules) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Print matrix
         # Disable default use of bash -x for easier to read output in the log


### PR DESCRIPTION
This possibly breaking release contains the following changes:

- Upgrade actions to versions that use node24 (actions/checkout v4 -> v7, docker/login-action v3 -> v4 and docker/metadata-action v5 -> v6) to prevent failure from September 16th 2026 onwards. (#146)

Successful test runs can be seen here:

- dev branch: https://github.com/NLnetLabs/ploutos-testing/actions/runs/31398937240
- main branch: https://github.com/NLnetLabs/ploutos-testing/actions/runs/31400674308
- release tag: https://github.com/NLnetLabs/ploutos-testing/actions/runs/31471896685

Release checklist:

- [x] 1. Create a branch in the RELEASE repo, let's call this the RELEASE branch.
- [ ] 2. Change RPM_MACROS_URL in the workflow to point to the new RELEASE branch.
- [x] 3. Create a PR in the RELEASE repo for the RELEASE branch.
- [x] 4. Create a matching branch in the TEST repo, let's call this the TEST branch.
- [x] 5. Make the desired changes to the RELEASE branch.
- [x] 6. In the TEST branch modify `.github/workflows/pkg.yml` so that instead of referring to `pkg-rust.yml@vX` it refers to `pkg-rust.yml@<Git ref of HEAD commit on the TEST branch>` or `pkg-rust.yml@<test branch name>`.
- [x] 7. Create a PR in the `ploutos-testing` repository from the TEST branch to `main`, let's call this the TEST PR.
- [x] 8. Repeat step 5 until the the `Packaging` workflow run in the TEST PR passes and behaves as desired.
- [x] 9. Merge the TEST PR to the `main` branch.
- [x] 10. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo against the `main` branch passes and behaves as desired. If not, repeat steps 4-9 until the new TEST PR passes and behaves as desired.
- [x] 11. Create a release tag in the TEST repo with the same release tag as will be used in the RELEASE repo, e.g. v1.2.3. _**Note:** Remember to respect semantic versioning, i.e. if the changes being made are not backward compatible you will need to bump the MAJOR version (in MAJOR.MINOR.PATCH) **and** any workflows that invoke the reusable workflow will need to be **manually edited** to refer to the new MAJOR version._
- [x] 12. Verify that the automatically invoked run of the `Packaging` workflow in the TEST repo passes against the newly created release tag passes and behaves as desired. If not, delete the release tag **in the TEST repo** and repeat steps 4-11 until the new TEST PR passes and behaves as desired.
- [x] 13. Merge the RELEASE PR to the `main` branch.
- [ ] 14. Change RPM_MACROS_URL in the workflow to point to vX.Y.Z tag (if your release branch has a different name).
- [x] 15. Create the new release vX.Y.Z tag in the RELEASE repo.
- [x] 16. Update the vX tag in the RELEASE repo to point to the new vX.Y.Z tag ([howto](https://github.com/NLnetLabs/ploutos/blob/main/docs/develop/README.md#release-process)).
- [x] 17. Edit `.github/workflows/pkg.yml` in the `main` branch of the TEST repo to refer again to `@vX`.
- [x] 18. Verify that the `Packaging` action in the TEST repo against the `main` branch passes and works as desired.
- [ ] 19. (optional) If the MAJOR version was changed, update affected repositories that use the reusable workflow to use the new MAJOR version, including adjusting to any breaking changes introduced by the MAJOR version change.
